### PR TITLE
feat(auth): cache GET /users/me for dashboard shell (#3)

### DIFF
--- a/docs/specs/sdd-dashboard-user-fetch-reduction.md
+++ b/docs/specs/sdd-dashboard-user-fetch-reduction.md
@@ -1,0 +1,77 @@
+# SDD: Reducir llamadas innecesarias a `GET /users/me` en el dashboard
+
+Documento de **Spec-Driven Development**: define el *qué* y los criterios de *hecho* antes de implementar. La implementación debe cumplir este spec (ajustar el spec si el contexto cambia).
+
+---
+
+## 1. Contexto
+
+Hoy, cada navegación dentro del dashboard dispara de nuevo la resolución del layout (RSC) y la función `getAuthenticatedUserState()` (`features/auth/services/session.ts`), que llama al backend `GET /users/me`. Eso genera tráfico y latencia sin un beneficio claro en cada click del menú.
+
+---
+
+## 2. Objetivo
+
+- Reducir la frecuencia de `GET /users/me` en navegación rutinaria del dashboard.
+- Forzar datos actualizados cuando el negocio o la seguridad lo requieren (no depender solo de la suerte).
+
+## 3. No objetivos
+
+- Eliminar por completo la validación frente al backend donde haga falta detectar sesión inválida.
+- Cache agresivo de permisos o datos sensibles sin estrategia de invalidación explícita.
+- Fijar un “máximo N peticiones por minuto” como política principal (preferir TTL + invalidación).
+
+---
+
+## 4. Requisitos funcionales
+
+| ID | Requisito |
+|----|-----------|
+| R1 | Tras una carga exitosa de perfil, las lecturas posteriores en un intervalo acotado **no** deben llamar al backend si el dato sigue considerado válido (política de frescura configurable; valor inicial sugerido: **≤ 60 s**). |
+| R2 | Cualquier evento de **invalidación** debe provocar que la siguiente lectura vuelva a ir al backend (o equivalente definido en implementación). Eventos mínimos: `401` / sesión inválida, **logout**, **éxito de actualización de perfil** (`PATCH` u operación equivalente). |
+| R3 | La UI del shell del dashboard (menú, usuario) debe seguir mostrando datos coherentes: no flicker grave ni estado “vacío” intermitente sin criterio definido en UX. |
+| R4 | Comportamiento en errores: si el backend falla tras invalidación, el spec de errores existente del proyecto aplica; no silenciar `401` / usuario eliminado. |
+
+---
+
+## 5. Criterios de aceptación (verificables)
+
+- **A1:** Con sesión válida, N navegaciones consecutivas entre rutas bajo `/dashboard` en menos del TTL **no** producen N llamadas `GET /users/me` (definir N en prueba; ej. ≥ 5 en &lt; 60 s ⇒ 1 llamada al backend en ese tramo, salvo invalidación).
+- **A2:** Tras simular o ejecutar actualización de perfil exitosa, la siguiente visualización del shell refleja el cambio (o fuerza refetch según decisión de diseño documentada en sub-§ 6.1).
+- **A3:** Tras `401` o flujo de logout documentado, no queda perfil “cacheado” mostrándose como autenticado.
+
+---
+
+## 6. Decisiones de implementación (rellenar antes de codificar)
+
+El spec **no** impone una sola técnica. La opción elegida se documenta aquí y debe enlazar con R1–R4.
+
+### 6.1 Estrategia elegida
+
+- [x] Caché en capa servidor (p. ej. Next `unstable_cache` / `fetch` con revalidación).
+- [ ] Caché en cliente (p. ej. Context + TTL): solo coherente si el shell **deja de depender** de un `GET /users/me` en cada petición del layout RSC; implica repartir claramente qué resuelve servidor vs cliente.
+- [ ] Datos mínimos en sesión (claims) para el shell + `GET /users/me` solo donde haga falta.
+- [ ] Otra: _______________
+
+**TTL acordado:** 60 s (`AUTH_USER_ME_CACHE.revalidateSeconds` en `lib/constants.ts`).
+
+**Invalidación explícita (disparadores):** `revalidateTag` vía `invalidateAuthenticatedUserProfileCache(accessToken)` en `features/auth/services/session.ts` — llamado desde `logout` (`features/auth/actions/auth.ts`); también tras `401` / usuario no encontrado en la respuesta de `/users/me`, y tras fallo de reintento con token refrescado. Las futuras server actions de actualización de perfil (`PATCH` / equivalente) deben llamar a `invalidateAuthenticatedUserProfileCache` con el token de la sesión en el mismo handler.
+
+---
+
+## 7. Referencias en código
+
+- `getAuthenticatedUserState`: `features/auth/services/session.ts`
+- Layout dashboard: `app/dashboard/layout.tsx`
+- Usos adicionales: `app/dashboard/page.tsx`, `app/dashboard/account/page.tsx`
+
+---
+
+## 8. Estado del spec
+
+| Campo | Valor |
+|-------|--------|
+| Estado | Aprobado (§ 6.1 cerrado; implementación en curso) |
+| Autor / fecha | — |
+
+Tras aprobar § 6.1, pasar estado a **Aprobado** y abrir tareas de implementación enlazadas a A1–A3.

--- a/features/auth/actions/auth.ts
+++ b/features/auth/actions/auth.ts
@@ -4,6 +4,7 @@ import { auth, signIn, signOut } from "@/auth"
 import { AuthError } from "next-auth"
 import { registerUser } from "@/features/auth/services/auth"
 import { logout as backendLogout } from "@/features/auth/services/logout"
+import { invalidateAuthenticatedUserProfileCache } from "@/features/auth/services/session"
 import { ApiError } from "@/lib/api-client"
 import type { RegisterFormState } from "@/features/auth/types"
 import type { ApiErrorResponse } from "@/types"
@@ -106,6 +107,7 @@ export async function logout() {
   const accessToken = session?.accessToken
 
   if (accessToken) {
+    invalidateAuthenticatedUserProfileCache(accessToken)
     try {
       await backendLogout(accessToken)
     } catch {

--- a/features/auth/services/session.ts
+++ b/features/auth/services/session.ts
@@ -1,7 +1,12 @@
+import { createHash } from "node:crypto"
 import { cache } from "react"
+import { unstable_cache, revalidateTag } from "next/cache"
 import { auth } from "@/auth"
 import { ApiError } from "@/lib/api-client"
-import { authenticatedApi } from "@/lib/authenticated-api-client"
+import {
+  executeAuthenticatedFetch,
+} from "@/lib/authenticated-api-client"
+import { AUTH_POLICY, AUTH_USER_ME_CACHE } from "@/lib/constants"
 import type { ApiErrorResponse } from "@/types"
 import { transitionSessionState } from "@/features/auth/lib/session-state-machine"
 import { trackAuthMetric } from "@/features/auth/services/telemetry"
@@ -35,6 +40,84 @@ function parseApiErrorBody(body: string): ApiErrorResponse | null {
   return null
 }
 
+function digestAccessToken(accessToken: string): string {
+  return createHash("sha256").update(accessToken).digest("hex")
+}
+
+export function userMeProfileCacheTag(accessToken: string): string {
+  return `${AUTH_USER_ME_CACHE.tagPrefix}:${digestAccessToken(accessToken)}`
+}
+
+/**
+ * Tras logout, actualización de perfil u otro evento que deba forzar `GET /users/me` fresco.
+ * Llamar desde server actions / route handlers con el token de la sesión actual.
+ */
+export function invalidateAuthenticatedUserProfileCache(accessToken: string) {
+  revalidateTag(userMeProfileCacheTag(accessToken), "default")
+}
+
+async function fetchCurrentUserWithRetry(
+  accessToken: string | undefined,
+): Promise<CurrentUser> {
+  if (!accessToken) {
+    throw new ApiError(
+      401,
+      JSON.stringify({
+        error: {
+          code: "UNAUTHENTICATED",
+          message: "Missing session",
+          status: 401,
+        },
+      }),
+    )
+  }
+
+  const runCached = (token: string) =>
+    unstable_cache(
+      async () =>
+        executeAuthenticatedFetch<{ data: CurrentUser }>(token, "/users/me"),
+      [
+        AUTH_USER_ME_CACHE.cacheKeyPrefix,
+        digestAccessToken(token),
+      ],
+      {
+        revalidate: AUTH_USER_ME_CACHE.revalidateSeconds,
+        tags: [userMeProfileCacheTag(token)],
+      },
+    )()
+
+  try {
+    const response = await runCached(accessToken)
+    return response.data
+  } catch (error) {
+    if (
+      error instanceof ApiError &&
+      error.status === 401 &&
+      AUTH_POLICY.retryUnauthorizedOnce
+    ) {
+      invalidateAuthenticatedUserProfileCache(accessToken)
+      const refreshedSession = await auth()
+      const nextToken = refreshedSession?.accessToken
+      if (!nextToken) {
+        throw error
+      }
+      try {
+        const response = await runCached(nextToken)
+        return response.data
+      } catch (retryErr) {
+        if (retryErr instanceof ApiError && retryErr.status === 401) {
+          invalidateAuthenticatedUserProfileCache(nextToken)
+        }
+        throw retryErr
+      }
+    }
+    if (error instanceof ApiError && error.status === 401) {
+      invalidateAuthenticatedUserProfileCache(accessToken)
+    }
+    throw error
+  }
+}
+
 export const getAuthenticatedUserState = cache(
   async (): Promise<AuthenticatedUserState> => {
   const session = await auth()
@@ -54,11 +137,11 @@ export const getAuthenticatedUserState = cache(
 
   try {
     status = transitionSessionState(status, "REFRESH_STARTED")
-    const response = await authenticatedApi<{ data: CurrentUser }>("/users/me")
+    const user = await fetchCurrentUserWithRetry(accessToken)
     status = transitionSessionState(status, "REFRESH_SUCCESS")
     return {
       status,
-      user: response.data,
+      user,
       shouldLogout: false,
     }
   } catch (error) {
@@ -70,6 +153,8 @@ export const getAuthenticatedUserState = cache(
         (error.status === 404 && code === "USER_NOT_FOUND")
 
       if (shouldInvalidateSession) {
+        invalidateAuthenticatedUserProfileCache(accessToken)
+
         if (error.status === 401) {
           trackAuthMetric("unauthorized401")
         }

--- a/lib/authenticated-api-client.ts
+++ b/lib/authenticated-api-client.ts
@@ -11,7 +11,7 @@ function getApiBaseUrl() {
   return process.env.BACKEND_URL
 }
 
-async function executeAuthenticatedFetch<T>(
+export async function executeAuthenticatedFetch<T>(
   accessToken: string,
   path: string,
   options?: AuthenticatedApiOptions,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -14,6 +14,13 @@ export const AUTH_POLICY = {
   retryUnauthorizedOnce: true,
 } as const
 
+/** Caché de `GET /users/me` en servidor (ver SDD dashboard user fetch). */
+export const AUTH_USER_ME_CACHE = {
+  revalidateSeconds: 60,
+  cacheKeyPrefix: "auth-users-me-v1",
+  tagPrefix: "auth-users-me-v1",
+} as const
+
 /** Rutas de auth del backend (ajustables sin tocar código) */
 export const BACKEND_AUTH_PATHS = {
   refresh: process.env.BACKEND_AUTH_REFRESH_PATH ?? "/auth/refresh",


### PR DESCRIPTION
## Summary

Implements server-side caching for `GET /users/me` during dashboard navigation, per [SDD](docs/specs/sdd-dashboard-user-fetch-reduction.md).

## Changes

- TTL-based cache (60s) with `revalidateTag` invalidation on logout, 401 / invalid session, and hooks for future profile PATCH.
- Spec document added under `docs/specs/`.

## Related

Closes #3

Made with [Cursor](https://cursor.com)