### PR TITLE
feat(dashboard): account page, breadcrumbs, and shell nav

### DIFF
--- a/app/dashboard/account/page.tsx
+++ b/app/dashboard/account/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next"
+import type { CurrentUser } from "@/features/auth/types"
+import { getAuthenticatedUserState } from "@/features/auth/services/session"
+import { AccountOverview } from "@/features/dashboard/components/account-overview"
+import type { AccountOverviewUser } from "@/features/dashboard/types"
+import { redirect } from "next/navigation"
+
+export const metadata: Metadata = {
+  title: "Cuenta",
+}
+
+function toAccountOverviewUser(user: CurrentUser): AccountOverviewUser {
+  return {
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    emailVerifiedAt: user.email_verified_at,
+    activeAccountId: user.active_account_id,
+    createdAt: user.created_at,
+    updatedAt: user.updated_at,
+  }
+}
+
+export default async function DashboardAccountPage() {
+  const { user, shouldLogout } = await getAuthenticatedUserState()
+
+  if (shouldLogout || !user) {
+    redirect("/api/auth/force-logout?next=/login")
+  }
+
+  return <AccountOverview user={toAccountOverviewUser(user)} />
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,12 +1,5 @@
 import { AppSidebar } from "@/features/dashboard/components/app-sidebar"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb"
+import { DashboardBreadcrumbs } from "@/features/dashboard/components/dashboard-breadcrumbs"
 import { Separator } from "@/components/ui/separator"
 import {
   SidebarInset,
@@ -50,17 +43,7 @@ export default async function DashboardLayout({
               orientation="vertical"
               className="mr-2 data-vertical:h-4 data-vertical:self-auto"
             />
-            <Breadcrumb>
-              <BreadcrumbList>
-                <BreadcrumbItem className="hidden md:block">
-                  <BreadcrumbLink href="/dashboard">Dashboard</BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator className="hidden md:block" />
-                <BreadcrumbItem>
-                  <BreadcrumbPage>Inicio</BreadcrumbPage>
-                </BreadcrumbItem>
-              </BreadcrumbList>
-            </Breadcrumb>
+            <DashboardBreadcrumbs />
           </div>
         </header>
         <main className="flex flex-1 flex-col gap-4 p-4 pt-0">

--- a/features/dashboard/components/account-overview.tsx
+++ b/features/dashboard/components/account-overview.tsx
@@ -1,0 +1,60 @@
+import type { AccountOverviewUser } from "@/features/dashboard/types"
+
+function formatDateTime(iso: string) {
+  try {
+    return new Intl.DateTimeFormat("es", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(iso))
+  } catch {
+    return iso
+  }
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid gap-1 border-b border-border py-3 last:border-b-0 sm:grid-cols-3 sm:gap-4">
+      <dt className="text-sm font-medium text-muted-foreground">{label}</dt>
+      <dd className="break-all text-sm sm:col-span-2">{value}</dd>
+    </div>
+  )
+}
+
+export function AccountOverview({ user }: { user: AccountOverviewUser }) {
+  const verifiedLabel = user.emailVerifiedAt
+    ? formatDateTime(user.emailVerifiedAt)
+    : "Sin verificar"
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Tu cuenta</h1>
+        <p className="text-muted-foreground">
+          Datos de tu perfil según el servidor.
+        </p>
+      </div>
+
+      <div className="rounded-xl border bg-card p-6 text-card-foreground shadow-sm">
+        <h2 className="mb-2 text-lg font-semibold">Perfil</h2>
+        <dl>
+          <DetailRow label="Nombre" value={user.name} />
+          <DetailRow label="Correo" value={user.email} />
+          <DetailRow label="Email verificado" value={verifiedLabel} />
+          <DetailRow label="ID de usuario" value={user.id} />
+          <DetailRow
+            label="Cuenta activa"
+            value={user.activeAccountId ?? "—"}
+          />
+          <DetailRow
+            label="Registro"
+            value={formatDateTime(user.createdAt)}
+          />
+          <DetailRow
+            label="Última actualización"
+            value={formatDateTime(user.updatedAt)}
+          />
+        </dl>
+      </div>
+    </div>
+  )
+}

--- a/features/dashboard/components/dashboard-breadcrumbs.tsx
+++ b/features/dashboard/components/dashboard-breadcrumbs.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+
+const CRUMB_LABELS: Record<string, string> = {
+  "/dashboard": "Inicio",
+  "/dashboard/account": "Cuenta",
+}
+
+export function DashboardBreadcrumbs() {
+  const pathname = usePathname() ?? "/dashboard"
+  const currentLabel = CRUMB_LABELS[pathname] ?? "Inicio"
+
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem className="hidden md:block">
+          <BreadcrumbLink asChild>
+            <Link href="/dashboard">Dashboard</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator className="hidden md:block" />
+        <BreadcrumbItem>
+          <BreadcrumbPage>{currentLabel}</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}

--- a/features/dashboard/components/nav-main.tsx
+++ b/features/dashboard/components/nav-main.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Link from "next/link"
 import {
   Collapsible,
   CollapsibleContent,
@@ -55,9 +56,9 @@ export function NavMain({
                   {item.items?.map((subItem) => (
                     <SidebarMenuSubItem key={subItem.title}>
                       <SidebarMenuSubButton asChild>
-                        <a href={subItem.url}>
+                        <Link href={subItem.url}>
                           <span>{subItem.title}</span>
-                        </a>
+                        </Link>
                       </SidebarMenuSubButton>
                     </SidebarMenuSubItem>
                   ))}

--- a/features/dashboard/components/nav-projects.tsx
+++ b/features/dashboard/components/nav-projects.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Link from "next/link"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -36,10 +37,10 @@ export function NavProjects({
         {projects.map((item) => (
           <SidebarMenuItem key={item.name}>
             <SidebarMenuButton asChild>
-              <a href={item.url}>
+              <Link href={item.url}>
                 {item.icon}
                 <span>{item.name}</span>
-              </a>
+              </Link>
             </SidebarMenuButton>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/features/dashboard/components/nav-user.tsx
+++ b/features/dashboard/components/nav-user.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Link from "next/link"
 import { useTransition } from "react"
 import {
   Avatar,
@@ -30,6 +31,7 @@ import {
   LogOutIcon,
 } from "lucide-react"
 import { logout } from "@/features/auth/actions/auth"
+import { ROUTES } from "@/lib/constants"
 
 function getInitials(name: string) {
   return name
@@ -103,9 +105,11 @@ export function NavUser({
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
-              <DropdownMenuItem>
-                <BadgeCheckIcon />
-                Account
+              <DropdownMenuItem asChild>
+                <Link href={ROUTES.dashboardAccount}>
+                  <BadgeCheckIcon />
+                  Cuenta
+                </Link>
               </DropdownMenuItem>
               <DropdownMenuItem>
                 <CreditCardIcon />

--- a/features/dashboard/types.ts
+++ b/features/dashboard/types.ts
@@ -1,0 +1,9 @@
+export interface AccountOverviewUser {
+  id: string
+  name: string
+  email: string
+  emailVerifiedAt: string | null
+  activeAccountId: string | null
+  createdAt: string
+  updatedAt: string
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -7,6 +7,7 @@ export const ROUTES = {
   forgotPassword: "/forgot-password",
   confirmEmail: "/confirm-email",
   dashboard: "/dashboard",
+  dashboardAccount: "/dashboard/account",
 } as const
 
 export const AUTH_POLICY = {


### PR DESCRIPTION
## Summary

Adds `/dashboard/account` with `AccountOverview` (RSC), `DashboardBreadcrumbs` in the dashboard layout, `ROUTES.dashboardAccount`, shared `features/dashboard/types`, and nav updates so the shell stays consistent with cached user data.

## Test plan

- `npm run lint`, `typecheck`, `test`, `build` (local).

Closes #5

Made with [Cursor](https://cursor.com)