### PR TITLE
fix(dashboard): set Playground nav item inactive by default

### DIFF
--- a/features/dashboard/components/app-sidebar.tsx
+++ b/features/dashboard/components/app-sidebar.tsx
@@ -49,7 +49,7 @@ const data = {
       title: "Playground",
       url: "#",
       icon: <TerminalSquareIcon />,
-      isActive: true,
+      isActive: false,
       items: [
         { title: "History", url: "#" },
         { title: "Starred", url: "#" },


### PR DESCRIPTION
## Summary
Sets `isActive: false` for the Playground item in `app-sidebar` mock data so no nav group is highlighted by default.

## Issue
Closes #7

## Checklist
- [x] Branch: `feature/sidebar-nav-default-state` (git-flow from `develop`)

Made with [Cursor](https://cursor.com)