### PR TITLE
feat(auth): improve registration and email verification UX

### DIFF
--- a/features/auth/actions/auth.ts
+++ b/features/auth/actions/auth.ts
@@ -5,9 +5,8 @@ import { AuthError } from "next-auth"
 import { registerUser } from "@/features/auth/services/auth"
 import { logout as backendLogout } from "@/features/auth/services/logout"
 import { invalidateAuthenticatedUserProfileCache } from "@/features/auth/services/session"
-import { ApiError } from "@/lib/api-client"
+import { ApiError, parseApiErrorBody } from "@/lib/api-client"
 import type { RegisterFormState } from "@/features/auth/types"
-import type { ApiErrorResponse } from "@/types"
 
 export async function login(
   _prevState: string | undefined,
@@ -54,7 +53,13 @@ export async function register(
     const message = res.meta.email_verification_required
       ? "Cuenta creada. Revisa tu correo para verificar tu email."
       : "Cuenta creada exitosamente. Ya puedes iniciar sesión."
-    return { success: true, message }
+    return {
+      success: true,
+      message,
+      ...(res.meta.email_verification_required && {
+        registeredEmail: res.data.email,
+      }),
+    }
   } catch (error) {
     if (error instanceof ApiError) {
       const parsed = parseApiErrorBody(error.body)
@@ -67,27 +72,6 @@ export async function register(
     }
     return { success: false, message: "Ocurrió un error inesperado." }
   }
-}
-
-function parseApiErrorBody(body: string): ApiErrorResponse | null {
-  try {
-    const data = JSON.parse(body) as unknown
-    if (
-      data &&
-      typeof data === "object" &&
-      "error" in data &&
-      data.error &&
-      typeof data.error === "object" &&
-      "code" in data.error &&
-      "message" in data.error &&
-      "status" in data.error
-    ) {
-      return data as ApiErrorResponse
-    }
-  } catch {
-    // body no es JSON válido
-  }
-  return null
 }
 
 function detailsToFormErrors(

--- a/features/auth/components/register-form.tsx
+++ b/features/auth/components/register-form.tsx
@@ -1,11 +1,129 @@
 "use client"
 
-import { useActionState } from "react"
 import Link from "next/link"
+import { Loader2 } from "lucide-react"
+import { useActionState, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { register } from "@/features/auth/actions/auth"
-import { Loader2 } from "lucide-react"
+import { resendVerificationEmail } from "@/features/auth/services/auth"
+import { ApiError, parseApiErrorBody } from "@/lib/api-client"
+
+const RESEND_SUCCESS_FALLBACK =
+  "If the email exists, a verification link has been sent"
+
+function resendVerificationUserMessage(code: string, fallback: string): string {
+  switch (code) {
+    case "EMAIL_ALREADY_VERIFIED":
+      return "Este correo ya está verificado. Puedes iniciar sesión."
+    case "RATE_LIMITED":
+    case "RATE_LIMIT_EXCEEDED":
+      return "Demasiadas solicitudes de verificación. Inténtalo más tarde."
+    default:
+      return fallback
+  }
+}
+
+type ResendUiState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; message: string }
+  | { status: "error"; message: string }
+
+interface RegisterSuccessNoticeProps {
+  message: string
+  registeredEmail?: string
+  isPendingForm: boolean
+}
+
+function RegisterSuccessNotice({
+  message,
+  registeredEmail,
+  isPendingForm,
+}: RegisterSuccessNoticeProps) {
+  const [resendState, setResendState] = useState<ResendUiState>({ status: "idle" })
+
+  async function handleResendVerification() {
+    if (!registeredEmail) return
+
+    setResendState({ status: "loading" })
+    try {
+      const res = await resendVerificationEmail({ email: registeredEmail })
+      const text = res.message?.trim()
+      setResendState({
+        status: "success",
+        message: text || RESEND_SUCCESS_FALLBACK,
+      })
+    } catch (error) {
+      if (error instanceof ApiError) {
+        const parsed = parseApiErrorBody(error.body)
+        const code = parsed?.error.code ?? ""
+        const fallback =
+          parsed?.error.message ?? `No se pudo reenviar el correo (${error.status}).`
+        setResendState({
+          status: "error",
+          message: resendVerificationUserMessage(code, fallback),
+        })
+        return
+      }
+      setResendState({
+        status: "error",
+        message: "No se pudo reenviar el correo. Inténtalo de nuevo.",
+      })
+    }
+  }
+
+  return (
+    <div className="mb-4 rounded-md bg-green-50 p-3 text-sm text-green-800 dark:bg-green-950 dark:text-green-200">
+      <p className="flex flex-wrap items-center gap-x-1 gap-y-2">
+        <span>{message}</span>
+        {registeredEmail ? (
+          <>
+            <span className="hidden sm:inline" aria-hidden>
+              ·
+            </span>
+            <Button
+              type="button"
+              variant="link"
+              className="h-auto min-h-0 p-0 text-sm font-medium text-green-800 underline-offset-4 hover:text-green-900 hover:underline dark:text-green-200 dark:hover:text-green-100"
+              disabled={resendState.status === "loading" || isPendingForm}
+              aria-busy={resendState.status === "loading"}
+              onClick={() => void handleResendVerification()}
+            >
+              {resendState.status === "loading" ? (
+                <>
+                  <Loader2
+                    className="mr-1 size-3.5 shrink-0 animate-spin"
+                    aria-hidden
+                  />
+                  Enviando…
+                </>
+              ) : (
+                "Reenviar correo de verificación"
+              )}
+            </Button>
+          </>
+        ) : null}
+        <span className="hidden sm:inline" aria-hidden>
+          ·
+        </span>
+        <Link href="/login" className="font-medium underline underline-offset-4">
+          Ir al login
+        </Link>
+      </p>
+      {resendState.status === "success" ? (
+        <p className="mt-2 text-xs text-green-900/90 dark:text-green-100/90" role="status">
+          {resendState.message}
+        </p>
+      ) : null}
+      {resendState.status === "error" ? (
+        <p className="mt-2 text-xs font-medium text-red-900 dark:text-red-200" role="alert">
+          {resendState.message}
+        </p>
+      ) : null}
+    </div>
+  )
+}
 
 export function RegisterForm() {
   const [state, formAction, isPending] = useActionState(register, undefined)
@@ -20,12 +138,12 @@ export function RegisterForm() {
       </div>
 
       {state?.success && (
-        <div className="mb-4 rounded-md bg-green-50 p-3 text-sm text-green-800 dark:bg-green-950 dark:text-green-200">
-          {state.message}{" "}
-          <Link href="/login" className="font-medium underline">
-            Ir al login
-          </Link>
-        </div>
+        <RegisterSuccessNotice
+          key={`${state.registeredEmail ?? ""}:${state.message}`}
+          message={state.message}
+          registeredEmail={state.registeredEmail}
+          isPendingForm={isPending}
+        />
       )}
 
       {state && !state.success && state.message && (

--- a/features/auth/services/auth.ts
+++ b/features/auth/services/auth.ts
@@ -7,6 +7,8 @@ import type {
   RefreshTokenResponse,
   RegisterRequest,
   RegisterResponse,
+  ResendVerificationRequest,
+  ResendVerificationResponse,
   VerifyEmailResponse,
 } from "@/features/auth/types"
 
@@ -19,6 +21,13 @@ export function loginUser(data: LoginRequest) {
 
 export function registerUser(data: RegisterRequest) {
   return api<RegisterResponse>("/auth/register", {
+    method: "POST",
+    body: data,
+  })
+}
+
+export function resendVerificationEmail(data: ResendVerificationRequest) {
+  return api<ResendVerificationResponse>("/auth/resend-verification", {
     method: "POST",
     body: data,
   })

--- a/features/auth/services/session.ts
+++ b/features/auth/services/session.ts
@@ -2,12 +2,11 @@ import { createHash } from "node:crypto"
 import { cache } from "react"
 import { unstable_cache, revalidateTag } from "next/cache"
 import { auth } from "@/auth"
-import { ApiError } from "@/lib/api-client"
+import { ApiError, parseApiErrorBody } from "@/lib/api-client"
 import {
   executeAuthenticatedFetch,
 } from "@/lib/authenticated-api-client"
 import { AUTH_POLICY, AUTH_USER_ME_CACHE } from "@/lib/constants"
-import type { ApiErrorResponse } from "@/types"
 import { transitionSessionState } from "@/features/auth/lib/session-state-machine"
 import { trackAuthMetric } from "@/features/auth/services/telemetry"
 import type { CurrentUser, SessionStatus } from "@/features/auth/types"
@@ -16,28 +15,6 @@ export interface AuthenticatedUserState {
   status: SessionStatus
   user: CurrentUser | null
   shouldLogout: boolean
-}
-
-function parseApiErrorBody(body: string): ApiErrorResponse | null {
-  try {
-    const data = JSON.parse(body) as unknown
-    if (
-      data &&
-      typeof data === "object" &&
-      "error" in data &&
-      data.error &&
-      typeof data.error === "object" &&
-      "code" in data.error &&
-      "message" in data.error &&
-      "status" in data.error
-    ) {
-      return data as ApiErrorResponse
-    }
-  } catch {
-    // Ignoramos body no JSON.
-  }
-
-  return null
 }
 
 function digestAccessToken(accessToken: string): string {

--- a/features/auth/types.ts
+++ b/features/auth/types.ts
@@ -43,12 +43,25 @@ export interface RegisterResponse {
 export interface RegisterFormState {
   success: boolean
   message: string
+  /** Email registrado cuando hace falta verificación; el cliente puede reenviar el enlace. */
+  registeredEmail?: string
   errors?: {
     name?: string[]
     email?: string[]
     password?: string[]
     confirmPassword?: string[]
   }
+}
+
+// ── Resend verification ──
+
+export interface ResendVerificationRequest {
+  email: string
+}
+
+/** 200: `{ "message": "If the email exists, a verification link has been sent" }` */
+export interface ResendVerificationResponse {
+  message: string
 }
 
 // ── Verify Email ──

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1,6 +1,29 @@
+import type { ApiErrorResponse } from "@/types"
+
 type ApiRequestOptions = Omit<RequestInit, "body"> & {
   body?: unknown
   next?: NextFetchRequestConfig
+}
+
+export function parseApiErrorBody(body: string): ApiErrorResponse | null {
+  try {
+    const data = JSON.parse(body) as unknown
+    if (
+      data &&
+      typeof data === "object" &&
+      "error" in data &&
+      data.error &&
+      typeof data.error === "object" &&
+      "code" in data.error &&
+      "message" in data.error &&
+      "status" in data.error
+    ) {
+      return data as ApiErrorResponse
+    }
+  } catch {
+    // body no es JSON válido
+  }
+  return null
 }
 
 function getApiBaseUrl() {


### PR DESCRIPTION
Expose registeredEmail after signup when verification is required,
add resend verification in the register success state, and move
parseApiErrorBody to api-client.

Refs #9
Closes #9

Made-with: Cursor