### PR TITLE
feat(auth): forgot and reset password flow

### DIFF
--- a/SETUP_PROGRESS.md
+++ b/SETUP_PROGRESS.md
@@ -1,134 +1,77 @@
-# Setup Progress — Cloudflax (Frontend)
+# SETUP_PROGRESS (SDD) — Forgot/Reset Password
 
-Seguimiento del avance en la implementación de auth (register/login), plantillas y dashboard.
+Documento base (compacto) para implementación guiada por especificación.
 
----
+## 1) Problema
 
-## Resumen del alcance
+El backend ya soporta recuperación de contraseña, pero el frontend no completa el flujo del enlace enviado por email.
 
-- **Auth**: Register y Login con estructura de plantillas compartida.
-- **Dashboard**: Área privada con su propia plantilla (layout).
-- **Progreso**: Tareas planificadas con estado [ ] pendiente / [x] hecho.
+## 2) Estado actual (fuente de verdad)
 
----
+- Backend (`api.cloudflax`):
+  - `POST /auth/forgot-password` (envía correo si aplica).
+  - `POST /auth/reset-password` (token + nueva contraseña).
+  - Link del email: `{FRONTEND_URL}/auth/reset-password?token=<token>`.
+- Frontend (`cloudflax`):
+  - Existe `/forgot-password` UI, sin integración real.
+  - Existe `/auth/verify-email`.
+  - No existe `/auth/reset-password`.
+  - `proxy.ts` no incluye `/auth/reset-password`.
 
-## 1. Estructura de plantillas (templates)
+## 3) Objetivo (Outcome)
 
-### 1.1 Grupo de rutas Auth (`app/(auth)/`)
+Usuario recibe email, abre link, define nueva contraseña, y puede volver a login.
 
-- [x] Crear `app/(auth)/layout.tsx` — Layout común para login y register (centrado, sin nav principal, fondo consistente).
-- [x] Definir interfaz/tipo para el layout de auth (título, subtítulo opcional, children).
-- [x] Opcional: componente `AuthTemplate` en `components/auth/` que reciba título y children para reutilizar la misma “card” o contenedor.
+## 4) Especificación funcional (SDD)
 
-### 1.2 Páginas Auth
+### 4.1 Requisitos
 
-- [x] `app/(auth)/login/page.tsx` — Página de login usando el layout/template de auth.
-- [x] `app/(auth)/register/page.tsx` — Página de registro usando el mismo layout/template de auth.
-- [x] Añadir `loading.tsx` en `app/(auth)/` para estado de carga (skeleton o spinner).
-- [x] Enlaces entre login ↔ register (“¿No tienes cuenta? Regístrate” / “¿Ya tienes cuenta? Inicia sesión”).
+- R1: `/forgot-password` debe llamar `POST /auth/forgot-password`.
+- R2: Crear `/auth/reset-password` que lea `token` de query.
+- R3: Form de reset debe llamar `POST /auth/reset-password` con `{ token, password }`.
+- R4: Validar en UI:
+  - `token` requerido.
+  - `password` min 8, max 72.
+  - confirmación coincide.
+- R5: Estados UX claros: `idle | loading | success | error`.
+- R6: No filtrar existencia de usuario en forgot-password (mensaje genérico).
 
-### 1.3 Grupo de rutas Dashboard (`app/(dashboard)/`)
+### 4.2 Contratos API (mínimos)
 
-- [x] Crear `app/(dashboard)/layout.tsx` — Layout del dashboard (sidebar/header, área de contenido).
-- [x] Definir estructura del template del dashboard (slot para contenido principal).
-- [x] `app/(dashboard)/dashboard/page.tsx` — Página principal del dashboard usando el template.
-- [x] `app/(dashboard)/loading.tsx` — Estado de carga del dashboard.
-- [x] `app/(dashboard)/error.tsx` — Error boundary para el área dashboard (requerido por ARCHITECTURE).
+- `POST /auth/forgot-password`
+  - req: `{ email: string }`
+  - ok: `200` + mensaje genérico
+  - limit: `429` + `Retry-After`
+- `POST /auth/reset-password`
+  - req: `{ token: string, password: string }`
+  - ok: `200` + mensaje éxito
+  - negocio: `422` token inválido/expirado
 
----
+### 4.3 Rutas frontend
 
-## 2. Implementación de Register
+- Mantener: `/forgot-password`
+- Crear: `/auth/reset-password`
+- Ajustar `proxy.ts`: agregar `/auth/reset-password` a rutas auth/matcher.
 
-- [x] Formulario de registro (email, contraseña, confirmar contraseña, nombre si aplica).
-- [x] Componente Client para el form (`components/auth/RegisterForm.tsx` o similar).
-- [x] Validación básica en cliente (campos requeridos, coincidencia de contraseñas).
-- [x] Mensajes de error accesibles (aria-live o rol alert).
-- [x] Integración con API/backend de register (mock en `/api/auth/register`; sustituir por backend real).
-- [x] Redirección tras registro exitoso (p. ej. a login o dashboard según criterio de producto).
+## 5) Plan de implementación (checklist)
 
----
+- [ ] `features/auth/types`: agregar tipos request/response de forgot/reset.
+- [ ] `features/auth/services/auth.ts`: agregar `requestPasswordReset` y `resetPassword`.
+- [ ] `app/(auth)/forgot-password/page.tsx`: conectar submit a API y estados.
+- [ ] `app/(auth)/auth/reset-password/page.tsx`: nueva página con token + formulario.
+- [ ] `proxy.ts`: incluir `/auth/reset-password`.
+- [ ] QA manual: flujo completo desde link de email.
 
-## 3. Implementación de Login (ya planificado en plantillas)
+## 6) Criterios de aceptación
 
-- [x] Formulario de login (email, contraseña).
-- [x] Componente Client para el form (`components/auth/LoginForm.tsx`).
-- [x] Validación básica y manejo de errores.
-- [x] Integración con API/backend de login (mock en `/api/auth/login`).
-- [x] Redirección tras login (dashboard o returnUrl).
+- CA1: Al enviar email válido/no válido en forgot, UI siempre muestra mensaje neutral.
+- CA2: Link con token válido permite reset y muestra éxito.
+- CA3: Link sin token o token inválido muestra error accionable.
+- CA4: Usuario puede volver a `/login` al finalizar.
+- CA5: Sin regresión en `/auth/verify-email`.
 
----
+## 7) Riesgos y decisiones
 
-## 4. Rutas y navegación
-
-- [x] En la home (`app/page.tsx`), enlaces a `/login` y `/register` (y opcionalmente a `/dashboard` para pruebas).
-- [x] Protección de rutas: middleware redirige no autenticados desde `/dashboard` a `/login?returnUrl=...`.
-
----
-
-## 5. Componentes compartidos
-
-- [x] `components/auth/AuthTemplate.tsx` — Contenedor común para login/register (opcional si se hace todo en layout).
-- [x] Componentes atómicos reutilizables: `Input`, `Button`, `Label` en `components/ui/`.
-
----
-
-## 6. Validación final (según AGENTS.md)
-
-- [x] `npm run lint` sin errores.
-- [x] `npm run build` correcto.
-- [x] Revisión de a11y en formularios (labels, aria-*, mensajes de error).
-
----
-
-## Orden sugerido de ejecución
-
-1. Estructura de plantillas: layout auth + layout dashboard + páginas placeholder.
-2. AuthTemplate y páginas login/register con formularios (UI primero, sin backend).
-3. Implementación de register (flujo completo cuando exista API).
-4. Implementación de login (flujo completo cuando exista API).
-5. Enlaces en home y, si aplica, protección de rutas (middleware).
-
----
-
-## Consideraciones para la ruta de trabajo
-
-Cosas a tener en cuenta para no dejarlas para después o para alinear decisiones.
-
-### Decisión de sesión y estado de auth
-
-- **Cómo saber si el usuario está logueado**: cookie (httpOnly), JWT en cookie/localStorage, o sesión en backend con cookie de sesión. Esto define cómo el middleware o los Server Components comprobarán la auth.
-- **Dónde vivir la lógica**: según ARCHITECTURE, los servicios de API y lógica de dominio van en `lib/`. Conviene crear desde el inicio algo como `lib/auth/` (o `lib/api/auth.ts`) para: tipos (`User`, `Session`), función para obtener sesión (ej. `getSession()`), y llamadas a register/login. Así el middleware y los formularios reutilizan lo mismo.
-
-### Protección de rutas y UX
-
-- **Return URL**: si un usuario no autenticado entra a `/dashboard` y se redirige a `/login`, guardar `returnUrl` (ej. query `?returnUrl=/dashboard`) y redirigir ahí tras login evita dejarle en la home sin contexto.
-- **Auth en layout**: el layout de `(dashboard)` puede comprobar sesión en el servidor y redirigir a `/login` si no hay sesión, en lugar de (o además de) middleware, para evitar flash de contenido privado.
-
-### Validación y formularios
-
-- **Una sola fuente de verdad**: usar una lib de validación (ej. Zod) y, si hace falta, react-hook-form permite reutilizar los mismos esquemas en cliente y (más adelante) en backend, y mejora accesibilidad de errores por campo. No está en el proyecto aún; se puede añadir cuando se implementen los forms.
-- **Estado de envío**: en submit hay que mostrar loading (botón deshabilitado o spinner) y manejar error de red/timeout de forma explícita (mensaje claro + a11y).
-
-### Calidad y arquitectura (alineado con AGENTS.md / ARCHITECTURE.md)
-
-- **Error boundary en dashboard**: ARCHITECTURE exige `error.tsx` para gestión de errores. Mejor tratar `app/(dashboard)/error.tsx` como **obligatorio** en esta ruta, no opcional.
-- **Metadata**: definir `metadata` (title, description) en cada página de auth y dashboard (ej. "Registro | Cloudflax") mejora pestaña y SEO aunque no se indexen.
-
-### Seguridad (recordatorio)
-
-- Formularios de login/register por **POST**; no enviar contraseñas por query params.
-- En producción, auth solo por **HTTPS**.
-- No loguear contraseñas ni tokens en consola.
-
-### Futuro opcional
-
-- **i18n**: si más adelante hay varios idiomas, tener textos de auth/dashboard en un módulo de strings o por props facilita el cambio.
-- **Tests**: tests unitarios o e2e en formularios de login/register y en protección de rutas dan confianza en refactors; se pueden planificar en una fase posterior.
-
----
-
-## Notas
-
-- Backend/API de auth: por definir (endpoints, sesión, JWT/cookies).
-- Diseño: usar tokens de Tailwind 4 y sistema de diseño del proyecto.
-- Los nombres de archivo y rutas pueden ajustarse (ej. `sign-in`/`sign-up` en lugar de `login`/`register`).
+- Riesgo: duplicar validaciones backend/frontend -> mantener reglas mínimas en UI (8-72).
+- Riesgo: UX inconsistente en errores API -> normalizar con `ApiError` + mensaje fallback.
+- Decisión: usar patrón existente de `verify-email` para minimizar superficie nueva.

--- a/app/(auth)/auth/reset-password/page.tsx
+++ b/app/(auth)/auth/reset-password/page.tsx
@@ -1,0 +1,15 @@
+import { ResetPasswordForm } from "@/features/auth/components/reset-password-form"
+
+type ResetPasswordPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}
+
+export default async function ResetPasswordPage({
+  searchParams,
+}: ResetPasswordPageProps) {
+  const resolved = searchParams ? await searchParams : undefined
+  const tokenParam = resolved?.token
+  const token = typeof tokenParam === "string" ? tokenParam : undefined
+
+  return <ResetPasswordForm token={token} />
+}

--- a/app/(auth)/auth/verify-email/page.tsx
+++ b/app/(auth)/auth/verify-email/page.tsx
@@ -3,6 +3,7 @@ import { CheckCircle2, Loader2, XCircle } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { verifyEmail } from "@/features/auth/services/auth"
+import { ROUTES } from "@/lib/constants"
 import { ApiError } from "@/lib/api-client"
 import type { ApiErrorResponse } from "@/types"
 
@@ -78,7 +79,7 @@ export default async function VerifyEmailPage({
       {!isLoading && (
         <div className="mt-8 space-y-3">
           <Button className="w-full" asChild>
-            <Link href="/login">Ir al inicio de sesión</Link>
+            <Link href={ROUTES.login}>Ir al inicio de sesión</Link>
           </Button>
         </div>
       )}

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,39 +1,5 @@
-import Link from "next/link"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { ArrowLeft } from "lucide-react"
+import { ForgotPasswordForm } from "@/features/auth/components/forgot-password-form"
 
 export default function ForgotPasswordPage() {
-  return (
-    <div className="rounded-xl border bg-card p-8 shadow-sm">
-      <div className="mb-6 text-center">
-        <h2 className="text-xl font-semibold">Recuperar contraseña</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Te enviaremos un enlace para restablecer tu contraseña
-        </p>
-      </div>
-
-      <form className="space-y-4">
-        <div className="space-y-2">
-          <label htmlFor="email" className="text-sm font-medium">
-            Correo electrónico
-          </label>
-          <Input id="email" type="email" placeholder="tu@email.com" />
-        </div>
-
-        <Button type="submit" className="w-full">
-          Enviar enlace de recuperación
-        </Button>
-      </form>
-
-      <div className="mt-6 text-center">
-        <Button variant="link" size="sm" asChild>
-          <Link href="/login">
-            <ArrowLeft className="mr-1.5 size-4" />
-            Volver al inicio de sesión
-          </Link>
-        </Button>
-      </div>
-    </div>
-  )
+  return <ForgotPasswordForm />
 }

--- a/features/auth/components/forgot-password-form.tsx
+++ b/features/auth/components/forgot-password-form.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import Link from "next/link"
+import { useState } from "react"
+import { ArrowLeft, Loader2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { requestPasswordReset } from "@/features/auth/services/auth"
+import { ApiError, parseApiErrorBody } from "@/lib/api-client"
+import { ROUTES } from "@/lib/constants"
+
+/** Same copy for any 200 response — does not reveal whether the email exists (CA1, R6). */
+const NEUTRAL_SUCCESS_MESSAGE =
+  "Si el correo está registrado, recibirás un enlace para restablecer la contraseña."
+
+type ForgotUiState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; message: string }
+  | { status: "error"; message: string }
+
+function rateLimitUserMessage(retryAfter?: string | null): string {
+  if (retryAfter) {
+    const seconds = Number.parseInt(retryAfter, 10)
+    if (!Number.isNaN(seconds) && seconds > 0) {
+      return `Demasiadas solicitudes. Vuelve a intentarlo en ${seconds} segundos.`
+    }
+  }
+  return "Demasiadas solicitudes. Espera un momento e inténtalo de nuevo."
+}
+
+export function ForgotPasswordForm() {
+  const [state, setState] = useState<ForgotUiState>({ status: "idle" })
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const form = e.currentTarget
+    const email = (new FormData(form).get("email") as string)?.trim()
+    if (!email) return
+
+    setState({ status: "loading" })
+    try {
+      await requestPasswordReset({ email })
+      setState({
+        status: "success",
+        message: NEUTRAL_SUCCESS_MESSAGE,
+      })
+      form.reset()
+    } catch (error) {
+      if (error instanceof ApiError) {
+        if (error.status === 429) {
+          setState({
+            status: "error",
+            message: rateLimitUserMessage(error.retryAfter),
+          })
+          return
+        }
+        const parsed = parseApiErrorBody(error.body)
+        const fallback =
+          parsed?.error.message ??
+          "No pudimos enviar el enlace. Inténtalo de nuevo."
+        setState({ status: "error", message: fallback })
+        return
+      }
+      setState({
+        status: "error",
+        message: "No pudimos enviar el enlace. Inténtalo de nuevo.",
+      })
+    }
+  }
+
+  const isLoading = state.status === "loading"
+  const showForm = state.status === "idle" || state.status === "loading"
+
+  return (
+    <div className="rounded-xl border bg-card p-8 shadow-sm">
+      <div className="mb-6 text-center">
+        <h2 className="text-xl font-semibold">Recuperar contraseña</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Te enviaremos un enlace para restablecer tu contraseña
+        </p>
+      </div>
+
+      {state.status === "success" ? (
+        <p
+          className="rounded-md bg-green-50 p-3 text-sm text-green-800 dark:bg-green-950 dark:text-green-200"
+          role="status"
+        >
+          {state.message}
+        </p>
+      ) : null}
+
+      {state.status === "error" ? (
+        <p className="mb-4 text-sm text-destructive" role="alert">
+          {state.message}
+        </p>
+      ) : null}
+
+      {showForm ? (
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="email" className="text-sm font-medium">
+              Correo electrónico
+            </label>
+            <Input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              placeholder="tu@email.com"
+              required
+              disabled={isLoading}
+            />
+          </div>
+
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading && <Loader2 className="mr-2 size-4 animate-spin" />}
+            Enviar enlace de recuperación
+          </Button>
+        </form>
+      ) : null}
+
+      {state.status === "success" ? (
+        <div className="mt-6 space-y-3">
+          <Button
+            type="button"
+            variant="secondary"
+            className="w-full"
+            onClick={() => setState({ status: "idle" })}
+          >
+            Enviar otro correo
+          </Button>
+          <Button variant="outline" className="w-full" asChild>
+            <Link href={ROUTES.login}>Ir al inicio de sesión</Link>
+          </Button>
+        </div>
+      ) : null}
+
+      <div className="mt-6 text-center">
+        <Button variant="link" size="sm" asChild>
+          <Link href={ROUTES.login}>
+            <ArrowLeft className="mr-1.5 size-4" />
+            Volver al inicio de sesión
+          </Link>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/features/auth/components/login-form.tsx
+++ b/features/auth/components/login-form.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { login } from "@/features/auth/actions/auth"
+import { ROUTES } from "@/lib/constants"
 import { Loader2 } from "lucide-react"
 
 export function LoginForm() {
@@ -42,7 +43,7 @@ export function LoginForm() {
               Contraseña
             </label>
             <Link
-              href="/forgot-password"
+              href={ROUTES.forgotPassword}
               className="text-xs text-muted-foreground hover:text-foreground"
             >
               ¿Olvidaste tu contraseña?
@@ -70,7 +71,7 @@ export function LoginForm() {
       <p className="mt-6 text-center text-sm text-muted-foreground">
         ¿No tienes cuenta?{" "}
         <Link
-          href="/register"
+          href={ROUTES.register}
           className="font-medium text-foreground hover:underline"
         >
           Regístrate

--- a/features/auth/components/register-form.tsx
+++ b/features/auth/components/register-form.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input"
 import { register } from "@/features/auth/actions/auth"
 import { resendVerificationEmail } from "@/features/auth/services/auth"
 import { ApiError, parseApiErrorBody } from "@/lib/api-client"
+import { ROUTES } from "@/lib/constants"
 
 const RESEND_SUCCESS_FALLBACK =
   "If the email exists, a verification link has been sent"
@@ -107,7 +108,7 @@ function RegisterSuccessNotice({
         <span className="hidden sm:inline" aria-hidden>
           ·
         </span>
-        <Link href="/login" className="font-medium underline underline-offset-4">
+        <Link href={ROUTES.login} className="font-medium underline underline-offset-4">
           Ir al login
         </Link>
       </p>
@@ -245,7 +246,7 @@ export function RegisterForm() {
       <p className="mt-6 text-center text-sm text-muted-foreground">
         ¿Ya tienes cuenta?{" "}
         <Link
-          href="/login"
+          href={ROUTES.login}
           className="font-medium text-foreground hover:underline"
         >
           Inicia sesión

--- a/features/auth/components/reset-password-form.tsx
+++ b/features/auth/components/reset-password-form.tsx
@@ -1,0 +1,208 @@
+"use client"
+
+import Link from "next/link"
+import { useState } from "react"
+import { CheckCircle2, Loader2, XCircle } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { resetPassword } from "@/features/auth/services/auth"
+import { ApiError, parseApiErrorBody } from "@/lib/api-client"
+import { ROUTES } from "@/lib/constants"
+
+const PASSWORD_MIN = 8
+const PASSWORD_MAX = 72
+
+type ResetUiState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; message: string }
+  | { status: "error"; message: string }
+
+interface ResetPasswordFormProps {
+  token: string | undefined
+}
+
+function validatePasswords(
+  password: string,
+  confirm: string,
+): string | null {
+  if (password.length < PASSWORD_MIN || password.length > PASSWORD_MAX) {
+    return `La contraseña debe tener entre ${PASSWORD_MIN} y ${PASSWORD_MAX} caracteres.`
+  }
+  if (password !== confirm) {
+    return "Las contraseñas no coinciden."
+  }
+  return null
+}
+
+export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
+  const [state, setState] = useState<ResetUiState>({ status: "idle" })
+  const [fieldError, setFieldError] = useState<string | null>(null)
+
+  const missingToken = !token?.trim()
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (!token?.trim()) return
+
+    const form = e.currentTarget
+    const fd = new FormData(form)
+    const password = (fd.get("password") as string) ?? ""
+    const confirmPassword = (fd.get("confirmPassword") as string) ?? ""
+
+    const validation = validatePasswords(password, confirmPassword)
+    if (validation) {
+      setFieldError(validation)
+      return
+    }
+    setFieldError(null)
+
+    setState({ status: "loading" })
+    try {
+      const res = await resetPassword({ token: token.trim(), password })
+      setState({
+        status: "success",
+        message:
+          res.message?.trim() ||
+          "Tu contraseña se ha actualizado. Ya puedes iniciar sesión.",
+      })
+    } catch (error) {
+      if (error instanceof ApiError) {
+        const parsed = parseApiErrorBody(error.body)
+        const message =
+          parsed?.error.message ??
+          (error.status === 422
+            ? "El enlace no es válido o ha expirado. Solicita uno nuevo desde recuperar contraseña."
+            : "No pudimos restablecer la contraseña. Inténtalo de nuevo.")
+        setState({ status: "error", message })
+        return
+      }
+      setState({
+        status: "error",
+        message: "No pudimos restablecer la contraseña. Inténtalo de nuevo.",
+      })
+    }
+  }
+
+  if (missingToken) {
+    return (
+      <div className="rounded-xl border bg-card p-8 shadow-sm text-center">
+        <div className="mx-auto mb-4 flex size-16 items-center justify-center rounded-full bg-destructive/10">
+          <XCircle className="size-8 text-destructive" aria-hidden />
+        </div>
+        <h2 className="text-xl font-semibold">Enlace no válido</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Falta el token de recuperación o el enlace está incompleto. Solicita un
+          nuevo correo desde recuperar contraseña.
+        </p>
+        <div className="mt-8 space-y-3">
+          <Button className="w-full" asChild>
+            <Link href={ROUTES.forgotPassword}>Solicitar nuevo enlace</Link>
+          </Button>
+          <Button variant="outline" className="w-full" asChild>
+            <Link href={ROUTES.login}>Ir al inicio de sesión</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  if (state.status === "success") {
+    return (
+      <div className="rounded-xl border bg-card p-8 shadow-sm text-center">
+        <div className="mx-auto mb-4 flex size-16 items-center justify-center rounded-full bg-primary/10">
+          <CheckCircle2 className="size-8 text-green-500" aria-hidden />
+        </div>
+        <h2 className="text-xl font-semibold">Contraseña actualizada</h2>
+        <p className="mt-2 text-sm text-muted-foreground" role="status">
+          {state.message}
+        </p>
+        <div className="mt-8">
+          <Button className="w-full" asChild>
+            <Link href={ROUTES.login}>Ir al inicio de sesión</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  const isLoading = state.status === "loading"
+
+  return (
+    <div className="rounded-xl border bg-card p-8 shadow-sm">
+      <div className="mb-6 text-center">
+        <h2 className="text-xl font-semibold">Nueva contraseña</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Elige una contraseña segura para tu cuenta
+        </p>
+      </div>
+
+      {state.status === "error" ? (
+        <p className="mb-4 text-sm text-destructive" role="alert">
+          {state.message}
+        </p>
+      ) : null}
+
+      {fieldError ? (
+        <p className="mb-4 text-sm text-destructive" role="alert">
+          {fieldError}
+        </p>
+      ) : null}
+
+      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+        <div className="space-y-2">
+          <label htmlFor="password" className="text-sm font-medium">
+            Nueva contraseña
+          </label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="new-password"
+            placeholder="••••••••"
+            required
+            minLength={PASSWORD_MIN}
+            maxLength={PASSWORD_MAX}
+            disabled={isLoading}
+            aria-invalid={Boolean(fieldError)}
+          />
+          <p className="text-xs text-muted-foreground">
+            Entre {PASSWORD_MIN} y {PASSWORD_MAX} caracteres
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="confirmPassword" className="text-sm font-medium">
+            Confirmar contraseña
+          </label>
+          <Input
+            id="confirmPassword"
+            name="confirmPassword"
+            type="password"
+            autoComplete="new-password"
+            placeholder="••••••••"
+            required
+            minLength={PASSWORD_MIN}
+            maxLength={PASSWORD_MAX}
+            disabled={isLoading}
+          />
+        </div>
+
+        <Button type="submit" className="w-full" disabled={isLoading}>
+          {isLoading && <Loader2 className="mr-2 size-4 animate-spin" />}
+          Guardar contraseña
+        </Button>
+      </form>
+
+      <p className="mt-6 text-center text-sm text-muted-foreground">
+        <Link
+          href={ROUTES.login}
+          className="font-medium text-foreground hover:underline"
+        >
+          Volver al inicio de sesión
+        </Link>
+      </p>
+    </div>
+  )
+}

--- a/features/auth/services/auth.ts
+++ b/features/auth/services/auth.ts
@@ -1,7 +1,9 @@
 import { api } from "@/lib/api-client"
-import { BACKEND_AUTH_PATHS } from "@/lib/constants"
+import { BACKEND_AUTH_PATHS, ROUTES } from "@/lib/constants"
 import type {
   CurrentUserResponse,
+  ForgotPasswordRequest,
+  ForgotPasswordResponse,
   LoginRequest,
   LoginResponse,
   RefreshTokenResponse,
@@ -9,6 +11,8 @@ import type {
   RegisterResponse,
   ResendVerificationRequest,
   ResendVerificationResponse,
+  ResetPasswordRequest,
+  ResetPasswordResponse,
   VerifyEmailResponse,
 } from "@/features/auth/types"
 
@@ -35,11 +39,25 @@ export function resendVerificationEmail(data: ResendVerificationRequest) {
 
 export function verifyEmail(token: string) {
   return api<VerifyEmailResponse>(
-    `/auth/verify-email?token=${encodeURIComponent(token)}`,
+    `${ROUTES.verifyEmail}?token=${encodeURIComponent(token)}`,
     {
       method: "GET",
     },
   )
+}
+
+export function requestPasswordReset(data: ForgotPasswordRequest) {
+  return api<ForgotPasswordResponse>("/auth/forgot-password", {
+    method: "POST",
+    body: data,
+  })
+}
+
+export function resetPassword(data: ResetPasswordRequest) {
+  return api<ResetPasswordResponse>(ROUTES.resetPassword, {
+    method: "POST",
+    body: data,
+  })
 }
 
 export function refreshAccessToken(refreshToken: string) {

--- a/features/auth/types.ts
+++ b/features/auth/types.ts
@@ -70,6 +70,26 @@ export interface VerifyEmailResponse {
   message: string
 }
 
+// ── Forgot / reset password ──
+
+export interface ForgotPasswordRequest {
+  email: string
+}
+
+/** 200: generic message (does not reveal whether the email exists). */
+export interface ForgotPasswordResponse {
+  message: string
+}
+
+export interface ResetPasswordRequest {
+  token: string
+  password: string
+}
+
+export interface ResetPasswordResponse {
+  message: string
+}
+
 // ── Session / Me ──
 
 export type AuthErrorCode =

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -35,6 +35,8 @@ export class ApiError extends Error {
   constructor(
     public status: number,
     public body: string,
+    /** Present when `status === 429` and the API sends `Retry-After`. */
+    public retryAfter?: string | null,
   ) {
     super(`API error ${status}: ${body}`)
     this.name = "ApiError"
@@ -64,7 +66,9 @@ export async function api<T>(
 
   if (!res.ok) {
     const text = await res.text()
-    throw new ApiError(res.status, text)
+    const retryAfter =
+      res.status === 429 ? res.headers.get("retry-after") : undefined
+    throw new ApiError(res.status, text, retryAfter)
   }
 
   const contentType = res.headers.get("content-type")

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -5,6 +5,8 @@ export const ROUTES = {
   login: "/login",
   register: "/register",
   forgotPassword: "/forgot-password",
+  verifyEmail: "/auth/verify-email",
+  resetPassword: "/auth/reset-password",
   confirmEmail: "/confirm-email",
   dashboard: "/dashboard",
   dashboardAccount: "/dashboard/account",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,13 +1,15 @@
 import { auth } from "@/auth"
+import { ROUTES } from "@/lib/constants"
 import { NextResponse } from "next/server"
 
 const AUTH_ROUTES = [
-  "/login",
-  "/register",
-  "/forgot-password",
-  "/confirm-email",
-  "/auth/verify-email",
-]
+  ROUTES.login,
+  ROUTES.register,
+  ROUTES.forgotPassword,
+  ROUTES.confirmEmail,
+  ROUTES.verifyEmail,
+  ROUTES.resetPassword,
+] as const satisfies readonly string[]
 
 type MiddlewareSession = {
   accessToken?: string
@@ -21,15 +23,16 @@ export default auth((req) => {
   )
 
   const { pathname } = req.nextUrl
-  if (pathname.startsWith("/dashboard") && !isLoggedIn) {
-    return NextResponse.redirect(new URL("/login", req.nextUrl))
+  if (pathname.startsWith(ROUTES.dashboard) && !isLoggedIn) {
+    return NextResponse.redirect(new URL(ROUTES.login, req.nextUrl))
   }
 
-  if (AUTH_ROUTES.includes(pathname) && isLoggedIn) {
-    return NextResponse.redirect(new URL("/dashboard", req.nextUrl))
+  if ((AUTH_ROUTES as readonly string[]).includes(pathname) && isLoggedIn) {
+    return NextResponse.redirect(new URL(ROUTES.dashboard, req.nextUrl))
   }
 })
 
+/** Next.js parses `matcher` at compile time — only string literals here. Keep aligned with `ROUTES` in `lib/constants.ts`. */
 export const config = {
   matcher: [
     "/dashboard/:path*",
@@ -38,6 +41,7 @@ export const config = {
     "/forgot-password",
     "/confirm-email",
     "/auth/verify-email",
+    "/auth/reset-password",
   ],
 }
 


### PR DESCRIPTION
## Summary

Completes the frontend forgot/reset password flow against the existing backend endpoints: `/auth/forgot-password`, `/auth/reset-password`, and the email link to `/auth/reset-password?token=`.

## Changes

- Forgot password page + form calling the API; reset password page reading `token` from query
- Auth service/types and API client updates; `proxy.ts` allows `/auth/reset-password`
- Related tweaks to verify-email, login/register forms, constants, and SDD progress doc

Closes #13

Made with [Cursor](https://cursor.com)