### PR TITLE
feat(auth): polish auth screens and verification flows

### DIFF
--- a/SETUP_PROGRESS.md
+++ b/SETUP_PROGRESS.md
@@ -103,8 +103,8 @@ Antes de pushear código de una fase, ejecuta al menos lo que toque el cambio (`
 
 ### Fase B — Calidad y consistencia (post-core)
 
-- [ ] Revisar que mensajes de error del reset usen el mismo patrón que el resto de auth (`parseApiErrorBody`, fallback coherente).
-- [ ] Confirmar con backend idempotencia o límites de reintentos del token en verify/reset si aplica.
+- [x] Errores API alineados: `rateLimitUserMessage` compartido (forgot + reset), `verify-email` usa `parseApiErrorBody`; reset trata **429** y fallback con código de estado si no hay cuerpo parseable.
+- [ ] **Seguimiento backend (manual):** idempotencia de `GET` verify-email y límites de uso del token de reset — documentar en contrato de API; no bloquea el cierre funcional del frontend.
 
 ---
 

--- a/SETUP_PROGRESS.md
+++ b/SETUP_PROGRESS.md
@@ -61,6 +61,32 @@ Tras recibir el correo, el usuario abre el enlace, establece una contraseña vá
 - **Body:** `{ "token": string, "password": string }`
 - **200:** éxito; UI muestra confirmación y enlace a login.
 - **422 (u otro acordado):** token inválido o expirado → mensaje claro; sin datos sensibles.
+- **429:** opcional; el cliente puede mostrar mensaje con `Retry-After` si el API lo envía (mismo patrón que forgot).
+
+### `GET /auth/verify-email` (relacionado con CA-5)
+
+- **Query:** `token` (string).
+- **Llamada desde frontend:** `GET {BACKEND_URL}/auth/verify-email?token=…` vía `verifyEmail()` en `features/auth/services/auth.ts`; la página RSC `app/(auth)/auth/verify-email/page.tsx` muestra éxito o error (`ApiError` + `parseApiErrorBody` o fallback).
+
+**Alineación pendiente con backend — idempotencia y re-ejecución**
+
+| Tema | Pregunta para el API / equipo backend | Acordado (rellenar tras alinear) |
+|------|---------------------------------------|----------------------------------|
+| Mismo enlace abierto otra vez cuando el correo **ya** estaba verificado | ¿Respuesta `200` idempotente con mensaje coherente? ¿Otro status (`409`, `422`, …)? ¿Efectos secundarios no deseados al repetir? | |
+| Token inválido vs expirado | ¿Se diferencia en HTTP o en cuerpo/mensaje? ¿Qué debe mostrar la UI en cada caso? | |
+
+### Política del token enviado en el correo de reset
+
+El enlace al usuario usa `token` en query en el frontend (`/auth/reset-password?token=…`); el valor lo emite y valida el backend.
+
+| Tema | Pregunta para el API / equipo backend | Acordado (rellenar tras alinear) |
+|------|---------------------------------------|----------------------------------|
+| Caducidad (TTL) | ¿Cuánto tiempo es válido el token desde el envío del correo? | |
+| Uso del token | ¿Un único `POST /auth/reset-password` exitoso invalida el token? ¿Reintentos con el mismo token tras error (p. ej. validación de contraseña)? | |
+| Varios correos / varios tokens | ¿Un nuevo `POST /auth/forgot-password` invalida tokens anteriores del mismo usuario? | |
+| Abuso y límites | ¿Hay rate limiting u otras reglas además del `429` ya contemplado en forgot? ¿Alguno específico en reset? | |
+
+**Registro:** cuando el equipo complete las columnas *Acordado*, anotar **fecha** y, si aplica, enlace a issue/ADR; entonces se puede marcar el ítem *Seguimiento backend* de la Fase B.
 
 ---
 
@@ -69,6 +95,7 @@ Tras recibir el correo, el usuario abre el enlace, establece una contraseña vá
 | Ruta / artefacto | Rol |
 |------------------|-----|
 | `/forgot-password` | Formulario forgot + estados |
+| `/auth/verify-email` | Verificación de correo con `token` en query (RSC + `verifyEmail`) |
 | `/auth/reset-password` | Token en query + formulario reset |
 | `features/auth/types.ts` | Tipos forgot / reset |
 | `features/auth/services/auth.ts` | `requestPasswordReset`, `resetPassword` |
@@ -99,12 +126,29 @@ Antes de pushear código de una fase, ejecuta al menos lo que toque el cambio (`
 - [x] `/forgot-password`: submit integrado, mensaje neutral, manejo de `429`.
 - [x] `/auth/reset-password`: página + formulario + validación 8–72 y confirmación.
 - [x] `proxy.ts`: `ROUTES.resetPassword` y entrada en `matcher`.
-- [ ] **QA manual:** flujo desde email real (staging): forgot → correo → reset → login.
+- [ ] **QA manual (entorno real):** Probar en **staging** (u otro entorno con **correo real**): **forgot → recepción del email → abrir el enlace → reset de contraseña → login.** Hasta que esta verificación esté hecha **y este checkbox marcado**, el ítem sigue abierto para el cierre de spec de la Fase A.
+
+#### Checklist de QA manual (ejecutar en staging o equivalente)
+
+Registrar **entorno** (URL frontend, que `BACKEND_URL` apunte al API correcto) y **email de prueba** con buzón real.
+
+| # | Acción | Resultado esperado (trazado a REQ/CA) |
+|---|--------|----------------------------------------|
+| 1 | Ir a `/forgot-password`, enviar un **email registrado** (trimado). | Mensaje de éxito **neutral**; no indica si el email existe (REQ-2, CA-1). |
+| 2 | Revisar correo. | Llega el mail; el enlace apunta a `{FRONTEND_URL}/auth/reset-password?token=…` (ver sección 1). |
+| 3 | Abrir el enlace (idealmente ventana o perfil limpio). | Formulario de reset; token tomado de query (REQ-3). |
+| 4 | Enviar contraseña nueva **8–72** caracteres y confirmación **coincidente**. | UI de éxito; camino claro a `/login` (REQ-4, REQ-5, REQ-6, CA-2, CA-4). |
+| 5 | Ir a `/login` e iniciar sesión con **la nueva contraseña**. | Sesión correcta (CA-2, alineado con outcome §3). |
+| 6 | *Opcional CA-1:* repetir paso 1 con email **no** registrado. | Mismo mensaje de éxito que en el paso 1. |
+| 7 | *Opcional CA-3 / regresión:* abrir `/auth/reset-password` sin `token` o con token inválido/expirado. | Error comprensible y siguiente paso claro (enlace a forgot o login). |
+| 8 | *Opcional CA-5:* flujo breve de `/auth/verify-email` (enlace válido) y login habitual. | Sin regresiones respecto al comportamiento previo. |
+
+**Cierre:** si todas las filas obligatorias (1–5) pasan, anotar **fecha** y **nota breve** (p. ej. incidencias o “OK”) debajo del checklist y marcar el checkbox **QA manual** de la Fase A.
 
 ### Fase B — Calidad y consistencia (post-core)
 
 - [x] Errores API alineados: `rateLimitUserMessage` compartido (forgot + reset), `verify-email` usa `parseApiErrorBody`; reset trata **429** y fallback con código de estado si no hay cuerpo parseable.
-- [ ] **Seguimiento backend (manual):** idempotencia de `GET` verify-email y límites de uso del token de reset — documentar en contrato de API; no bloquea el cierre funcional del frontend.
+- [ ] **Seguimiento backend (manual):** Completar las tablas *Acordado* en la **sección 5** (`GET /auth/verify-email` y política del token de reset) con lo que defina el API / equipo backend, y registrar fecha o referencia (issue, ADR). Hasta entonces el ítem sigue abierto; la **plantilla** en la sección 5 ya está lista para rellenar.
 
 ---
 
@@ -132,5 +176,7 @@ Antes de pushear código de una fase, ejecuta al menos lo que toque el cambio (`
 
 ## 11. Definición de hecho (DoD)
 
-- Criterios **CA-1…CA-5** verificados en entorno de prueba.
-- Pipeline local del repo: `lint` → `typecheck` → `test` → `build` sin fallos.
+- **CA-1…CA-5** en entorno de prueba: dependen del **QA manual** de la Fase A (flujo completo hasta login) y, donde corresponda, de lo **acordado con backend** (verify-email, límites del token).
+- **Pipeline local del repo:** `lint` → `typecheck` → `test` → `build` sin fallos. En desarrollo habitual suele cumplirse al iterar; para el **cierre formal** de esta spec, ejecutar la secuencia completa una vez antes de marcar el cierre y, si ayuda al equipo, anotar fecha o resultado del QA junto al checklist de la sección 8.
+
+**Resumen de pendientes ejecutables desde frontend / verificación:** lo único que este documento deja como verificación **ejecutable** antes de dar la spec por cerrada es el **QA manual** del flujo completo (y marcar el checkbox o una nota breve al validarlo). El ítem de backend es **coordinación y documentación de contrato**, no código frontend pendiente listado como implementación.

--- a/SETUP_PROGRESS.md
+++ b/SETUP_PROGRESS.md
@@ -1,77 +1,136 @@
-# SETUP_PROGRESS (SDD) — Forgot/Reset Password
+# Spec — Recuperación de contraseña (forgot / reset)
 
-Documento base (compacto) para implementación guiada por especificación.
+Documento bajo **Spec-Driven Development (SDD)**: la especificación guía la implementación; el código debe poder trazarse a un requisito o criterio de aceptación.
 
-## 1) Problema
+**Cómo usar este doc**
 
-El backend ya soporta recuperación de contraseña, pero el frontend no completa el flujo del enlace enviado por email.
+1. **Congelar el contrato**: API y reglas de negocio acordados antes de tocar UI.
+2. **Implementar contra la spec**: cada tarea del plan enlaza con un `REQ` o `CA`.
+3. **Cerrar con verificación**: criterios de aceptación + `lint` → `typecheck` → `test` → `build` (ver `AGENTS.md`).
+4. **Versionar por fase**: al terminar una fase del plan (§8), un **solo commit** que cubra solo esa fase; mensajes en inglés, [Conventional Commits](https://www.conventionalcommits.org/) (detalle en §7).
 
-## 2) Estado actual (fuente de verdad)
+---
 
-- Backend (`api.cloudflax`):
-  - `POST /auth/forgot-password` (envía correo si aplica).
-  - `POST /auth/reset-password` (token + nueva contraseña).
-  - Link del email: `{FRONTEND_URL}/auth/reset-password?token=<token>`.
-- Frontend (`cloudflax`):
-  - Existe `/forgot-password` UI, sin integración real.
-  - Existe `/auth/verify-email`.
-  - No existe `/auth/reset-password`.
-  - `proxy.ts` no incluye `/auth/reset-password`.
+## 1. Contexto
 
-## 3) Objetivo (Outcome)
+| Ámbito | Nota |
+|--------|------|
+| Backend | `POST /auth/forgot-password`, `POST /auth/reset-password`. Enlace del email: `{FRONTEND_URL}/auth/reset-password?token=…` |
+| Frontend | App Next.js; rutas públicas de auth listadas en `proxy.ts` (`ROUTES` en `lib/constants.ts`) |
+| Patrones | Cliente llama API vía `features/auth/services/auth.ts`; errores con `ApiError` y `parseApiErrorBody` |
 
-Usuario recibe email, abre link, define nueva contraseña, y puede volver a login.
+---
 
-## 4) Especificación funcional (SDD)
+## 2. Problema
 
-### 4.1 Requisitos
+Garantizar que un usuario con enlace de correo pueda **restablecer la contraseña** sin fricción, sin filtrar si el email existe en “olvidé mi contraseña”, y con mensajes de error **accionables** en reset.
 
-- R1: `/forgot-password` debe llamar `POST /auth/forgot-password`.
-- R2: Crear `/auth/reset-password` que lea `token` de query.
-- R3: Form de reset debe llamar `POST /auth/reset-password` con `{ token, password }`.
-- R4: Validar en UI:
-  - `token` requerido.
-  - `password` min 8, max 72.
-  - confirmación coincide.
-- R5: Estados UX claros: `idle | loading | success | error`.
-- R6: No filtrar existencia de usuario en forgot-password (mensaje genérico).
+---
 
-### 4.2 Contratos API (mínimos)
+## 3. Outcome (éxito medible)
 
-- `POST /auth/forgot-password`
-  - req: `{ email: string }`
-  - ok: `200` + mensaje genérico
-  - limit: `429` + `Retry-After`
-- `POST /auth/reset-password`
-  - req: `{ token: string, password: string }`
-  - ok: `200` + mensaje éxito
-  - negocio: `422` token inválido/expirado
+Tras recibir el correo, el usuario abre el enlace, establece una contraseña válida, ve confirmación clara y puede **volver a iniciar sesión** en `/login`.
 
-### 4.3 Rutas frontend
+---
 
-- Mantener: `/forgot-password`
-- Crear: `/auth/reset-password`
-- Ajustar `proxy.ts`: agregar `/auth/reset-password` a rutas auth/matcher.
+## 4. Especificación funcional
 
-## 5) Plan de implementación (checklist)
+| ID | Requisito |
+|----|-----------|
+| **REQ-1** | La pantalla `/forgot-password` envía `POST /auth/forgot-password` con `{ email }` trimado. |
+| **REQ-2** | Tras un envío exitoso, la UI muestra **siempre** el mismo mensaje neutro (no revelar si el email está registrado). |
+| **REQ-3** | Existe `/auth/reset-password` que lee `token` de query. Sin token válido en contexto de uso: estado de error accionable. |
+| **REQ-4** | El formulario de reset llama `POST /auth/reset-password` con `{ token, password }`. |
+| **REQ-5** | Validación mínima en cliente: `password` longitud 8–72; confirmación coincide con `password`. |
+| **REQ-6** | Estados UX explícitos: *idle → loading → success* o *error* (forgot y reset). |
+| **REQ-7** | Respuesta HTTP **429** en forgot: mensaje al usuario usando `Retry-After` cuando exista. |
+| **REQ-8** | `proxy.ts`: ruta `/auth/reset-password` incluida en lista auth y en `matcher`, alineado con `ROUTES`. |
 
-- [ ] `features/auth/types`: agregar tipos request/response de forgot/reset.
-- [ ] `features/auth/services/auth.ts`: agregar `requestPasswordReset` y `resetPassword`.
-- [ ] `app/(auth)/forgot-password/page.tsx`: conectar submit a API y estados.
-- [ ] `app/(auth)/auth/reset-password/page.tsx`: nueva página con token + formulario.
-- [ ] `proxy.ts`: incluir `/auth/reset-password`.
-- [ ] QA manual: flujo completo desde link de email.
+---
 
-## 6) Criterios de aceptación
+## 5. Contratos API (mínimos)
 
-- CA1: Al enviar email válido/no válido en forgot, UI siempre muestra mensaje neutral.
-- CA2: Link con token válido permite reset y muestra éxito.
-- CA3: Link sin token o token inválido muestra error accionable.
-- CA4: Usuario puede volver a `/login` al finalizar.
-- CA5: Sin regresión en `/auth/verify-email`.
+### `POST /auth/forgot-password`
 
-## 7) Riesgos y decisiones
+- **Body:** `{ "email": string }`
+- **200:** respuesta genérica compatible con mensaje neutral en UI.
+- **429:** opcional `Retry-After` (header), tratado en cliente.
 
-- Riesgo: duplicar validaciones backend/frontend -> mantener reglas mínimas en UI (8-72).
-- Riesgo: UX inconsistente en errores API -> normalizar con `ApiError` + mensaje fallback.
-- Decisión: usar patrón existente de `verify-email` para minimizar superficie nueva.
+### `POST /auth/reset-password`
+
+- **Body:** `{ "token": string, "password": string }`
+- **200:** éxito; UI muestra confirmación y enlace a login.
+- **422 (u otro acordado):** token inválido o expirado → mensaje claro; sin datos sensibles.
+
+---
+
+## 6. Superficie frontend (referencia)
+
+| Ruta / artefacto | Rol |
+|------------------|-----|
+| `/forgot-password` | Formulario forgot + estados |
+| `/auth/reset-password` | Token en query + formulario reset |
+| `features/auth/types.ts` | Tipos forgot / reset |
+| `features/auth/services/auth.ts` | `requestPasswordReset`, `resetPassword` |
+| `proxy.ts` | Matcher y redirecciones auth/dashboard |
+
+---
+
+## 7. Commits por fase (Git)
+
+**Regla:** un commit cuando **todos** los ítems de una fase están hechos (no mezclar Fase A y B en el mismo commit). Si solo actualizas esta spec, puede ser un commit aparte `docs(spec): …`.
+
+| Momento | Qué incluye el commit | Mensaje sugerido (inglés) |
+|--------|------------------------|---------------------------|
+| Cierre **Fase A** (código) | Tipos, servicios, páginas forgot/reset, `proxy.ts` | `feat(auth): add forgot and reset password flow` |
+| Cierre **Fase A** (solo QA + doc) | Notas breves en este archivo o checklist marcado tras prueba en staging | `docs(auth): complete password reset spec QA` o `chore(auth): verify forgot-reset flow in staging` |
+| Cierre **Fase B** | Ajustes de errores / alineación con backend | `refactor(auth): align reset password error handling` (o `fix` si corrige bug visible) |
+
+Antes de pushear código de una fase, ejecuta al menos lo que toque el cambio (`lint` → `typecheck`; `test` / `build` si afecta comportamiento crítico). Convención del repo: `docs/communication.md` § Commits.
+
+---
+
+## 8. Plan de trabajo
+
+### Fase A — Implementación core
+
+- [x] Tipos request/response forgot + reset en `features/auth/types`.
+- [x] Servicio: `requestPasswordReset` y `resetPassword` en `features/auth/services/auth.ts`.
+- [x] `/forgot-password`: submit integrado, mensaje neutral, manejo de `429`.
+- [x] `/auth/reset-password`: página + formulario + validación 8–72 y confirmación.
+- [x] `proxy.ts`: `ROUTES.resetPassword` y entrada en `matcher`.
+- [ ] **QA manual:** flujo desde email real (staging): forgot → correo → reset → login.
+
+### Fase B — Calidad y consistencia (post-core)
+
+- [ ] Revisar que mensajes de error del reset usen el mismo patrón que el resto de auth (`parseApiErrorBody`, fallback coherente).
+- [ ] Confirmar con backend idempotencia o límites de reintentos del token en verify/reset si aplica.
+
+---
+
+## 9. Criterios de aceptación
+
+| ID | Criterio |
+|----|----------|
+| **CA-1** | Forgot: mismo mensaje de éxito para email existente o inexistente (REQ-2). |
+| **CA-2** | Reset con token válido: contraseña actualizada y UI de éxito + acceso a `/login`. |
+| **CA-3** | Sin token o token inválido/expirado: error comprensible y siguiente paso claro (p. ej. volver a forgot o login). |
+| **CA-4** | Enlaces y copy permiten volver a `/login` al terminar el flujo. |
+| **CA-5** | Sin regresión en `/auth/verify-email` ni en el login tras los cambios. |
+
+---
+
+## 10. Riesgos y decisiones
+
+| Tipo | Descripción |
+|------|-------------|
+| **Riesgo** | Duplicar reglas con el backend → mantener solo validación **mínima** en UI (8–72 + confirmación). |
+| **Riesgo** | Errores API heterogéneos → centralizar parsing y mensaje fallback. |
+| **Decisión** | Reutilizar patrones de otras pantallas auth (feedback, shell, `ApiError`) para mantener UX homogénea. |
+
+---
+
+## 11. Definición de hecho (DoD)
+
+- Criterios **CA-1…CA-5** verificados en entorno de prueba.
+- Pipeline local del repo: `lint` → `typecheck` → `test` → `build` sin fallos.

--- a/app/(auth)/auth/verify-email/page.tsx
+++ b/app/(auth)/auth/verify-email/page.tsx
@@ -5,9 +5,8 @@ import { Button } from "@/components/ui/button"
 import { AuthFormShell } from "@/features/auth/components/auth-form-shell"
 import { AuthFormStatusPanel } from "@/features/auth/components/auth-form-status"
 import { verifyEmail } from "@/features/auth/services/auth"
-import { ApiError } from "@/lib/api-client"
+import { ApiError, parseApiErrorBody } from "@/lib/api-client"
 import { ROUTES } from "@/lib/constants"
-import type { ApiErrorResponse } from "@/types"
 
 type Status = "success" | "error"
 
@@ -38,12 +37,10 @@ export default async function VerifyEmailPage({
     } catch (error) {
       status = "error"
       if (error instanceof ApiError) {
-        try {
-          const parsed = JSON.parse(error.body) as ApiErrorResponse
-          message = parsed.error?.message ?? "No fue posible verificar tu correo."
-        } catch {
-          message = "No fue posible verificar tu correo."
-        }
+        const parsed = parseApiErrorBody(error.body)
+        message =
+          parsed?.error.message ??
+          "No fue posible verificar tu correo."
       } else {
         message = "No fue posible verificar tu correo."
       }

--- a/app/(auth)/auth/verify-email/page.tsx
+++ b/app/(auth)/auth/verify-email/page.tsx
@@ -1,10 +1,12 @@
 import Link from "next/link"
-import { CheckCircle2, Loader2, XCircle } from "lucide-react"
+import { CheckCircle2, XCircle } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
+import { AuthFormShell } from "@/features/auth/components/auth-form-shell"
+import { AuthFormStatusPanel } from "@/features/auth/components/auth-form-status"
 import { verifyEmail } from "@/features/auth/services/auth"
-import { ROUTES } from "@/lib/constants"
 import { ApiError } from "@/lib/api-client"
+import { ROUTES } from "@/lib/constants"
 import type { ApiErrorResponse } from "@/types"
 
 type Status = "success" | "error"
@@ -48,42 +50,32 @@ export default async function VerifyEmailPage({
     }
   }
 
-  const isLoading = false
-
   return (
-    <div className="rounded-xl border bg-card p-8 shadow-sm text-center">
-      <div className="mx-auto mb-4 flex size-16 items-center justify-center rounded-full bg-primary/10">
-        {isLoading ? (
-          <Loader2 className="size-8 animate-spin text-primary" />
-        ) : status === "success" ? (
-          <CheckCircle2 className="size-8 text-green-500" />
-        ) : (
-          <XCircle className="size-8 text-destructive" />
-        )}
-      </div>
-
-      <h2 className="text-xl font-semibold">
-        {isLoading
-          ? "Verificando tu correo..."
-          : status === "success"
+    <AuthFormShell className="text-center">
+      <AuthFormStatusPanel
+        icon={
+          status === "success" ? (
+            <CheckCircle2 className="size-8 text-emerald-500" aria-hidden />
+          ) : (
+            <XCircle className="size-8 text-destructive" aria-hidden />
+          )
+        }
+        title={
+          status === "success"
             ? "Correo verificado"
-            : "No se pudo verificar tu correo"}
-      </h2>
-
-      <p className="mt-2 text-sm text-muted-foreground">
-        {isLoading
-          ? "Estamos validando tu enlace de verificación. Esto puede tardar unos segundos."
-          : message}
-      </p>
-
-      {!isLoading && (
-        <div className="mt-8 space-y-3">
-          <Button className="w-full" asChild>
-            <Link href={ROUTES.login}>Ir al inicio de sesión</Link>
-          </Button>
-        </div>
-      )}
-    </div>
+            : "No se pudo verificar tu correo"
+        }
+        description={message}
+        iconRingClassName={
+          status === "success" ? "bg-primary/10" : "bg-destructive/10"
+        }
+        descriptionRole={status === "success" ? "status" : "alert"}
+      />
+      <div className="space-y-3">
+        <Button className="h-10 w-full cursor-pointer shadow-sm" asChild>
+          <Link href={ROUTES.login}>Ir al inicio de sesión</Link>
+        </Button>
+      </div>
+    </AuthFormShell>
   )
 }
-

--- a/app/(auth)/confirm-email/page.tsx
+++ b/app/(auth)/confirm-email/page.tsx
@@ -1,35 +1,15 @@
-import Link from "next/link"
-import { MailCheck } from "lucide-react"
+import { ConfirmEmailForm } from "@/features/auth/components/confirm-email-form"
 
-import { Button } from "@/components/ui/button"
-import { AuthFormShell } from "@/features/auth/components/auth-form-shell"
-import { AuthFormStatusPanel } from "@/features/auth/components/auth-form-status"
-import { ROUTES } from "@/lib/constants"
+type ConfirmEmailPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}
 
-export default function ConfirmEmailPage() {
-  return (
-    <AuthFormShell className="text-center">
-      <AuthFormStatusPanel
-        icon={<MailCheck className="size-8 text-primary" aria-hidden />}
-        title="Confirma tu correo"
-        description="Hemos enviado un enlace de verificación a tu correo electrónico. Revisa tu bandeja de entrada y haz clic en el enlace para activar tu cuenta."
-      />
-      <div className="space-y-3">
-        <Button
-          variant="outline"
-          className="h-10 w-full cursor-pointer shadow-sm"
-        >
-          Reenviar correo de verificación
-        </Button>
-        <p className="text-center text-sm text-muted-foreground">
-          <Link
-            href={ROUTES.login}
-            className="font-medium text-foreground hover:underline"
-          >
-            Volver al inicio de sesión
-          </Link>
-        </p>
-      </div>
-    </AuthFormShell>
-  )
+export default async function ConfirmEmailPage({
+  searchParams,
+}: ConfirmEmailPageProps) {
+  const resolved = searchParams ? await searchParams : undefined
+  const emailParam = resolved?.email
+  const initialEmail = typeof emailParam === "string" ? emailParam : undefined
+
+  return <ConfirmEmailForm initialEmail={initialEmail ?? ""} />
 }

--- a/app/(auth)/confirm-email/page.tsx
+++ b/app/(auth)/confirm-email/page.tsx
@@ -1,29 +1,35 @@
 import Link from "next/link"
-import { Button } from "@/components/ui/button"
 import { MailCheck } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { AuthFormShell } from "@/features/auth/components/auth-form-shell"
+import { AuthFormStatusPanel } from "@/features/auth/components/auth-form-status"
+import { ROUTES } from "@/lib/constants"
 
 export default function ConfirmEmailPage() {
   return (
-    <div className="rounded-xl border bg-card p-8 shadow-sm text-center">
-      <div className="mx-auto mb-4 flex size-16 items-center justify-center rounded-full bg-primary/10">
-        <MailCheck className="size-8 text-primary" />
-      </div>
-
-      <h2 className="text-xl font-semibold">Confirma tu correo</h2>
-      <p className="mt-2 text-sm text-muted-foreground">
-        Hemos enviado un enlace de verificación a tu correo electrónico.
-        Revisa tu bandeja de entrada y haz clic en el enlace para activar tu
-        cuenta.
-      </p>
-
-      <div className="mt-8 space-y-3">
-        <Button variant="outline" className="w-full">
+    <AuthFormShell className="text-center">
+      <AuthFormStatusPanel
+        icon={<MailCheck className="size-8 text-primary" aria-hidden />}
+        title="Confirma tu correo"
+        description="Hemos enviado un enlace de verificación a tu correo electrónico. Revisa tu bandeja de entrada y haz clic en el enlace para activar tu cuenta."
+      />
+      <div className="space-y-3">
+        <Button
+          variant="outline"
+          className="h-10 w-full cursor-pointer shadow-sm"
+        >
           Reenviar correo de verificación
         </Button>
-        <Button variant="link" size="sm" asChild>
-          <Link href="/login">Volver al inicio de sesión</Link>
-        </Button>
+        <p className="text-center text-sm text-muted-foreground">
+          <Link
+            href={ROUTES.login}
+            className="font-medium text-foreground hover:underline"
+          >
+            Volver al inicio de sesión
+          </Link>
+        </p>
       </div>
-    </div>
+    </AuthFormShell>
   )
 }

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -31,7 +31,7 @@ export default function AuthLayout({
           <div className="w-full max-w-md">
             <div className="inline-flex items-center justify-center gap-2 text-sm font-semibold text-primary">
               <Store className="size-4 shrink-0" />
-              Comercio y operaciones
+              Comercio y operaciones, conectados
             </div>
             <h1 className="mt-5 text-3xl font-bold leading-tight">
               Gestiona tu negocio con una experiencia fluida y segura

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,6 +1,14 @@
 import Link from "next/link"
+import {
+  ArrowRight,
+  LayoutDashboard,
+  ShieldCheck,
+  ShoppingBag,
+  Sparkles,
+  Store,
+} from "lucide-react"
+
 import { Button } from "@/components/ui/button"
-import { ShoppingBag, LayoutDashboard } from "lucide-react"
 
 export default function AuthLayout({
   children,
@@ -8,30 +16,75 @@ export default function AuthLayout({
   children: React.ReactNode
 }>) {
   return (
-    <div className="flex min-h-svh flex-col items-center justify-center bg-muted/40 px-4 py-12">
-      <div className="mb-8 text-center">
-        <h1 className="text-2xl font-bold tracking-tight">Cloudflax</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Plataforma de comercio electrónico
-        </p>
+    <div className="relative min-h-svh overflow-hidden bg-muted/30 px-4 py-10 lg:px-8 lg:py-14">
+      <div className="pointer-events-none absolute left-1/2 top-0 h-64 w-[36rem] -translate-x-1/2 rounded-full bg-primary/10 blur-3xl" />
+
+      <div className="relative mx-auto grid w-full max-w-6xl items-stretch gap-6 lg:grid-cols-2">
+        <aside className="hidden px-4 py-6 lg:flex lg:flex-col lg:justify-between">
+          <div>
+            <div className="inline-flex items-center text-sm font-semibold text-primary">
+              <Store className="mr-2 size-4" />
+              Comercio y operaciones
+            </div>
+            <h1 className="mt-5 text-3xl font-bold leading-tight">
+              Gestiona tu negocio con una experiencia fluida y segura
+            </h1>
+            <p className="mt-4 max-w-md text-sm text-muted-foreground">
+              Accede al panel y administra productos, pedidos y clientes en un
+              solo lugar
+            </p>
+          </div>
+
+          <div className="space-y-3 text-muted-foreground">
+            <div className="flex items-center gap-2.5 text-sm">
+              <ShieldCheck className="size-4" />
+              Proteccion de sesion y credenciales
+            </div>
+            <div className="flex items-center gap-2.5 text-sm">
+              <LayoutDashboard className="size-4" />
+              Acceso rapido al dashboard de operaciones
+            </div>
+            <div className="flex items-center gap-2.5 text-sm">
+              <ShoppingBag className="size-4" />
+              Gestion conectada con la tienda
+            </div>
+          </div>
+        </aside>
+
+        <div className="flex flex-col">
+          <div className="mb-6 flex justify-center sm:justify-start">
+            <div className="inline-flex items-center gap-1.5 text-sm font-semibold tracking-tight">
+              <Sparkles className="size-4 text-primary" />
+              Cloudflax
+            </div>
+          </div>
+
+          <div className="mx-auto flex w-full max-w-md flex-1 flex-col justify-center">
+            {children}
+          </div>
+
+          <nav
+            className="mt-10 flex flex-col items-center gap-2 sm:mt-8"
+            aria-label="Navegación secundaria"
+          >
+            <Button
+              variant="outline"
+              size="lg"
+              className="h-11 min-w-[min(100%,17.5rem)] cursor-pointer rounded-full border-border/80 bg-background/90 px-6 shadow-sm backdrop-blur-sm transition-all hover:border-primary/35 hover:bg-background hover:shadow-md"
+              asChild
+            >
+              <Link href="/" className="gap-2.5">
+                <ShoppingBag className="size-4 text-primary" />
+                <span className="font-semibold">Ir a la tienda</span>
+                <ArrowRight className="size-4 text-muted-foreground transition-transform duration-200 group-hover/button:translate-x-0.5" />
+              </Link>
+            </Button>
+            <p className="max-w-xs text-center text-xs leading-relaxed text-muted-foreground">
+              Explora productos y ofertas desde la tienda
+            </p>
+          </nav>
+        </div>
       </div>
-
-      <div className="w-full max-w-md">{children}</div>
-
-      <nav className="mt-10 flex items-center gap-3">
-        <Button variant="ghost" size="sm" asChild>
-          <Link href="/">
-            <ShoppingBag className="mr-1.5 size-4" />
-            Tienda
-          </Link>
-        </Button>
-        <Button variant="ghost" size="sm" asChild>
-          <Link href="/dashboard">
-            <LayoutDashboard className="mr-1.5 size-4" />
-            Dashboard
-          </Link>
-        </Button>
-      </nav>
     </div>
   )
 }

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,11 +1,18 @@
 import Link from "next/link"
 import {
   ArrowRight,
+  BarChart3,
+  Bot,
+  ContactRound,
   LayoutDashboard,
+  Package,
+  Share2,
   ShieldCheck,
   ShoppingBag,
   Sparkles,
   Store,
+  Truck,
+  Users,
 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
@@ -20,33 +27,70 @@ export default function AuthLayout({
       <div className="pointer-events-none absolute left-1/2 top-0 h-64 w-[36rem] -translate-x-1/2 rounded-full bg-primary/10 blur-3xl" />
 
       <div className="relative mx-auto grid w-full max-w-6xl items-stretch gap-6 lg:grid-cols-2">
-        <aside className="hidden px-4 py-6 lg:flex lg:flex-col lg:justify-between">
-          <div>
-            <div className="inline-flex items-center text-sm font-semibold text-primary">
-              <Store className="mr-2 size-4" />
+        <aside className="hidden px-4 py-6 lg:flex lg:flex-col lg:items-center lg:justify-between lg:text-center">
+          <div className="w-full max-w-md">
+            <div className="inline-flex items-center justify-center gap-2 text-sm font-semibold text-primary">
+              <Store className="size-4 shrink-0" />
               Comercio y operaciones
             </div>
             <h1 className="mt-5 text-3xl font-bold leading-tight">
               Gestiona tu negocio con una experiencia fluida y segura
             </h1>
-            <p className="mt-4 max-w-md text-sm text-muted-foreground">
+            <p className="mt-4 text-sm text-muted-foreground">
               Accede al panel y administra productos, pedidos y clientes en un
               solo lugar
             </p>
           </div>
 
-          <div className="space-y-3 text-muted-foreground">
-            <div className="flex items-center gap-2.5 text-sm">
-              <ShieldCheck className="size-4" />
-              Proteccion de sesion y credenciales
+          <div
+            className="flex w-full min-w-0 min-h-[clamp(16rem,42vh,34rem)] flex-1 flex-col items-center justify-center py-6"
+            aria-hidden
+          >
+            <div className="relative aspect-square w-full max-w-[22rem] shrink-0 lg:max-w-[25.5rem]">
+              <div className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center justify-center text-primary">
+                <LayoutDashboard className="size-10 lg:size-12" strokeWidth={1.45} />
+              </div>
+
+              {/* Octágono regular (R≈31 vb): métricas, redes, envíos, clientes, tienda, CRM, pedidos, IA */}
+              <div className="absolute left-1/2 top-[19%] flex -translate-x-1/2 -translate-y-1/2 items-center justify-center text-primary/88">
+                <BarChart3 className="size-6 lg:size-7" strokeWidth={1.45} />
+              </div>
+              <div className="absolute left-[72%] top-[28.1%] flex -translate-x-1/2 -translate-y-1/2 items-center justify-center text-primary/88">
+                <Share2 className="size-6 lg:size-7" strokeWidth={1.45} />
+              </div>
+              <div className="absolute left-[81%] top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center justify-center text-primary/88">
+                <Truck className="size-6 lg:size-7" strokeWidth={1.45} />
+              </div>
+              <div className="absolute left-[72%] top-[72%] flex -translate-x-1/2 -translate-y-1/2 items-center justify-center text-primary/88">
+                <Users className="size-6 lg:size-7" strokeWidth={1.45} />
+              </div>
+              <div className="absolute left-1/2 top-[81%] flex -translate-x-1/2 -translate-y-1/2 items-center justify-center text-primary/88">
+                <ShoppingBag className="size-6 lg:size-7" strokeWidth={1.45} />
+              </div>
+              <div className="absolute left-[28.1%] top-[72%] flex -translate-x-1/2 -translate-y-1/2 items-center justify-center text-primary/88">
+                <ContactRound className="size-6 lg:size-7" strokeWidth={1.45} />
+              </div>
+              <div className="absolute left-[19%] top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center justify-center text-primary/88">
+                <Package className="size-6 lg:size-7" strokeWidth={1.45} />
+              </div>
+              <div className="absolute left-[28.1%] top-[28.1%] flex -translate-x-1/2 -translate-y-1/2 items-center justify-center text-primary/88">
+                <Bot className="size-6 lg:size-7" strokeWidth={1.45} />
+              </div>
             </div>
-            <div className="flex items-center gap-2.5 text-sm">
-              <LayoutDashboard className="size-4" />
-              Acceso rapido al dashboard de operaciones
+          </div>
+
+          <div className="w-full max-w-md space-y-3 text-muted-foreground">
+            <div className="flex items-center justify-center gap-2.5 text-sm">
+              <ShieldCheck className="size-4 shrink-0 text-primary" />
+              Protección de sesión y credenciales
             </div>
-            <div className="flex items-center gap-2.5 text-sm">
-              <ShoppingBag className="size-4" />
-              Gestion conectada con la tienda
+            <div className="flex items-center justify-center gap-2.5 text-sm">
+              <LayoutDashboard className="size-4 shrink-0 text-primary" />
+              Acceso rápido al dashboard de operaciones
+            </div>
+            <div className="flex items-center justify-center gap-2.5 text-sm">
+              <ShoppingBag className="size-4 shrink-0 text-primary" />
+              Gestión conectada con la tienda
             </div>
           </div>
         </aside>

--- a/app/(store)/layout.tsx
+++ b/app/(store)/layout.tsx
@@ -45,20 +45,12 @@ export default async function StoreLayout({
                 </form>
               </>
             ) : (
-              <>
-                <Button variant="ghost" size="sm" asChild>
-                  <Link href="/login">
-                    <UserCircle className="mr-1.5 size-4" />
-                    Iniciar sesión
-                  </Link>
-                </Button>
-                <Button variant="ghost" size="sm" asChild>
-                  <Link href="/dashboard">
-                    <LayoutDashboard className="mr-1.5 size-4" />
-                    Dashboard
-                  </Link>
-                </Button>
-              </>
+              <Button variant="ghost" size="sm" asChild>
+                <Link href="/login">
+                  <UserCircle className="mr-1.5 size-4" />
+                  Iniciar sesión
+                </Link>
+              </Button>
             )}
           </nav>
         </div>

--- a/auth.ts
+++ b/auth.ts
@@ -2,14 +2,13 @@ import NextAuth from "next-auth"
 import { ApiError } from "@/lib/api-client"
 import { AUTH_POLICY } from "@/lib/constants"
 import Credentials from "next-auth/providers/credentials"
+import { decodeAccessTokenIdentity } from "@/features/auth/lib/decode-access-token-payload"
+import {
+  throwFromLoginApiError,
+  throwInvalidAccessTokenPayload,
+} from "@/features/auth/lib/login-credentials-error"
 import { trackAuthMetric } from "@/features/auth/services/telemetry"
 import { loginUser, refreshAccessToken } from "@/features/auth/services/auth"
-
-function decodeJwtPayload(token: string): Record<string, unknown> {
-  const base64 = token.split(".")[1]
-  const json = Buffer.from(base64, "base64url").toString("utf-8")
-  return JSON.parse(json) as Record<string, unknown>
-}
 
 function hasTokenExpired(expiresAt?: string) {
   if (!expiresAt) return true
@@ -70,17 +69,20 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         try {
           const res = await loginUser({ email, password })
           const { access_token, refresh_token, expires_at } = res.data
-          const payload = decodeJwtPayload(access_token)
+          const identity = decodeAccessTokenIdentity(access_token)
+          if (!identity) {
+            throwInvalidAccessTokenPayload()
+          }
 
           return {
-            id: payload.user_id as string,
-            email: payload.email as string,
+            id: identity.userId,
+            email: identity.email,
             accessToken: access_token,
             refreshToken: refresh_token,
             expiresAt: expires_at,
           }
         } catch (error) {
-          if (error instanceof ApiError) return null
+          if (error instanceof ApiError) throwFromLoginApiError(error)
           throw error
         }
       },

--- a/features/auth/actions/auth.ts
+++ b/features/auth/actions/auth.ts
@@ -1,7 +1,8 @@
 "use server"
 
 import { auth, signIn, signOut } from "@/auth"
-import { AuthError } from "next-auth"
+import { AuthError, CredentialsSignin } from "next-auth"
+import { rateLimitUserMessage } from "@/features/auth/lib/rate-limit-message"
 import { registerUser } from "@/features/auth/services/auth"
 import { logout as backendLogout } from "@/features/auth/services/logout"
 import { invalidateAuthenticatedUserProfileCache } from "@/features/auth/services/session"
@@ -19,13 +20,24 @@ export async function login(
       redirectTo: "/dashboard",
     })
   } catch (error) {
-    if (error instanceof AuthError) {
-      switch (error.type) {
-        case "CredentialsSignin":
-          return "Correo o contraseña incorrectos. Revísalos e inténtalo de nuevo."
+    if (error instanceof CredentialsSignin) {
+      switch (error.code) {
+        case "email_not_verified":
+          return "Verifica tu correo antes de iniciar sesión. Revisa tu bandeja o solicita un nuevo enlace desde la página de registro o de confirmación."
+        case "rate_limited": {
+          const r = error.cause?.retryAfter
+          const retryAfter =
+            typeof r === "string" || r == null ? r : String(r)
+          return rateLimitUserMessage(retryAfter)
+        }
+        case "invalid_session":
+          return "No pudimos completar debido a un problema técnico. Inténtalo de nuevo."
         default:
-          return "Ocurrió un error inesperado."
+          return "Correo o contraseña incorrectos. Revísalos e inténtalo de nuevo."
       }
+    }
+    if (error instanceof AuthError) {
+      return "Ocurrió un error inesperado."
     }
     throw error
   }

--- a/features/auth/actions/auth.ts
+++ b/features/auth/actions/auth.ts
@@ -22,7 +22,7 @@ export async function login(
     if (error instanceof AuthError) {
       switch (error.type) {
         case "CredentialsSignin":
-          return "Credenciales inválidas."
+          return "Correo o contraseña incorrectos. Revísalos e inténtalo de nuevo."
         default:
           return "Ocurrió un error inesperado."
       }

--- a/features/auth/components/auth-form-feedback.tsx
+++ b/features/auth/components/auth-form-feedback.tsx
@@ -1,0 +1,63 @@
+import { cn } from "@/lib/utils"
+
+interface AuthFormErrorAlertProps {
+  children: React.ReactNode
+  className?: string
+  id?: string
+  role?: "alert"
+}
+
+export function AuthFormErrorAlert({
+  children,
+  className,
+  id,
+  role = "alert",
+}: AuthFormErrorAlertProps) {
+  return (
+    <p
+      id={id}
+      role={role}
+      className={cn(
+        "rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive",
+        className,
+      )}
+    >
+      {children}
+    </p>
+  )
+}
+
+interface AuthFormSuccessAlertProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export function AuthFormSuccessAlert({
+  children,
+  className,
+}: AuthFormSuccessAlertProps) {
+  return (
+    <div
+      role="status"
+      className={cn(
+        "rounded-md border border-emerald-500/20 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-950 dark:border-emerald-400/30 dark:bg-emerald-400/10 dark:text-emerald-50",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+interface AuthFormFieldErrorProps {
+  children: React.ReactNode
+  id: string
+}
+
+export function AuthFormFieldError({ children, id }: AuthFormFieldErrorProps) {
+  return (
+    <p id={id} className="text-xs text-destructive" role="alert">
+      {children}
+    </p>
+  )
+}

--- a/features/auth/components/auth-form-footer.tsx
+++ b/features/auth/components/auth-form-footer.tsx
@@ -1,0 +1,25 @@
+interface AuthFormTrustNoteProps {
+  children: React.ReactNode
+}
+
+export function AuthFormTrustNote({ children }: AuthFormTrustNoteProps) {
+  return (
+    <p className="mx-auto mt-6 max-w-sm text-center text-xs leading-relaxed text-muted-foreground">
+      {children}
+    </p>
+  )
+}
+
+interface AuthFormAlternateActionProps {
+  children: React.ReactNode
+}
+
+export function AuthFormAlternateAction({
+  children,
+}: AuthFormAlternateActionProps) {
+  return (
+    <p className="mt-6 text-center text-sm text-muted-foreground">
+      {children}
+    </p>
+  )
+}

--- a/features/auth/components/auth-form-header.tsx
+++ b/features/auth/components/auth-form-header.tsx
@@ -1,0 +1,30 @@
+import type { LucideIcon } from "lucide-react"
+
+interface AuthFormHeaderProps {
+  eyebrow?: { icon: LucideIcon; label: string }
+  title: string
+  description?: string
+}
+
+export function AuthFormHeader({
+  eyebrow,
+  title,
+  description,
+}: AuthFormHeaderProps) {
+  const EyebrowIcon = eyebrow?.icon
+
+  return (
+    <div className="mb-7 space-y-3 text-center">
+      {eyebrow && EyebrowIcon ? (
+        <div className="mx-auto inline-flex items-center text-xs font-medium text-muted-foreground">
+          <EyebrowIcon className="mr-1.5 size-3.5 text-primary" />
+          {eyebrow.label}
+        </div>
+      ) : null}
+      <h2 className="text-2xl font-semibold tracking-tight">{title}</h2>
+      {description ? (
+        <p className="text-sm text-muted-foreground">{description}</p>
+      ) : null}
+    </div>
+  )
+}

--- a/features/auth/components/auth-form-shell.tsx
+++ b/features/auth/components/auth-form-shell.tsx
@@ -1,0 +1,19 @@
+import { cn } from "@/lib/utils"
+
+interface AuthFormShellProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export function AuthFormShell({ children, className }: AuthFormShellProps) {
+  return (
+    <div
+      className={cn(
+        "mx-2 mt-4 rounded-2xl bg-background/60 px-8 py-12 sm:mx-0 sm:px-10 sm:py-14",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/features/auth/components/auth-form-status.tsx
+++ b/features/auth/components/auth-form-status.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@/lib/utils"
+
+interface AuthFormStatusPanelProps {
+  icon: React.ReactNode
+  title: string
+  description: string
+  iconRingClassName?: string
+  descriptionRole?: "status" | "alert"
+  children?: React.ReactNode
+}
+
+export function AuthFormStatusPanel({
+  icon,
+  title,
+  description,
+  iconRingClassName = "bg-primary/10",
+  descriptionRole,
+  children,
+}: AuthFormStatusPanelProps) {
+  return (
+    <>
+      <div className="mb-7 text-center">
+        <div
+          className={cn(
+            "mx-auto mb-4 flex size-16 items-center justify-center rounded-full",
+            iconRingClassName,
+          )}
+        >
+          {icon}
+        </div>
+        <h2 className="text-2xl font-semibold tracking-tight">{title}</h2>
+        <p className="mt-2 text-sm text-muted-foreground" role={descriptionRole}>
+          {description}
+        </p>
+      </div>
+      {children}
+    </>
+  )
+}

--- a/features/auth/components/auth-icon-input.tsx
+++ b/features/auth/components/auth-icon-input.tsx
@@ -1,0 +1,21 @@
+import type { LucideIcon } from "lucide-react"
+
+import { Input } from "@/components/ui/input"
+import { cn } from "@/lib/utils"
+
+interface AuthIconInputProps extends React.ComponentProps<typeof Input> {
+  icon: LucideIcon
+}
+
+export function AuthIconInput({
+  icon: Icon,
+  className,
+  ...props
+}: AuthIconInputProps) {
+  return (
+    <div className="relative">
+      <Icon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+      <Input className={cn("h-10 pl-9", className)} {...props} />
+    </div>
+  )
+}

--- a/features/auth/components/confirm-email-form.tsx
+++ b/features/auth/components/confirm-email-form.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import Link from "next/link"
+import { Loader2, Mail, MailCheck } from "lucide-react"
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  AuthFormErrorAlert,
+  AuthFormSuccessAlert,
+} from "@/features/auth/components/auth-form-feedback"
+import { AuthFormShell } from "@/features/auth/components/auth-form-shell"
+import { AuthFormStatusPanel } from "@/features/auth/components/auth-form-status"
+import { AuthIconInput } from "@/features/auth/components/auth-icon-input"
+import {
+  RESEND_VERIFICATION_NEUTRAL_SUCCESS,
+  resendVerificationErrorFromApiError,
+} from "@/features/auth/lib/resend-verification"
+import { resendVerificationEmail } from "@/features/auth/services/auth"
+import { ApiError } from "@/lib/api-client"
+import { ROUTES } from "@/lib/constants"
+
+type ResendUiState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; message: string }
+  | { status: "error"; message: string }
+
+export interface ConfirmEmailFormProps {
+  initialEmail?: string
+}
+
+export function ConfirmEmailForm({ initialEmail = "" }: ConfirmEmailFormProps) {
+  const [email, setEmail] = useState(initialEmail.trim())
+  const [resendState, setResendState] = useState<ResendUiState>({
+    status: "idle",
+  })
+
+  async function handleResend() {
+    const trimmed = email.trim()
+    if (!trimmed) {
+      setResendState({
+        status: "error",
+        message: "Introduce el correo con el que te registraste.",
+      })
+      return
+    }
+
+    setResendState({ status: "loading" })
+    try {
+      const res = await resendVerificationEmail({ email: trimmed })
+      const text = res.message?.trim()
+      setResendState({
+        status: "success",
+        message: text || RESEND_VERIFICATION_NEUTRAL_SUCCESS,
+      })
+    } catch (error) {
+      if (error instanceof ApiError) {
+        setResendState({
+          status: "error",
+          message: resendVerificationErrorFromApiError(error),
+        })
+        return
+      }
+      setResendState({
+        status: "error",
+        message: "No se pudo reenviar el correo. Inténtalo de nuevo.",
+      })
+    }
+  }
+
+  const isLoading = resendState.status === "loading"
+
+  return (
+    <AuthFormShell className="text-center">
+      <AuthFormStatusPanel
+        icon={<MailCheck className="size-8 text-primary" aria-hidden />}
+        title="Confirma tu correo"
+        description="Hemos enviado un enlace de verificación a tu correo electrónico. Revisa tu bandeja de entrada y haz clic en el enlace para activar tu cuenta."
+      />
+
+      {resendState.status === "success" ? (
+        <AuthFormSuccessAlert className="mb-4 text-left">
+          {resendState.message}
+        </AuthFormSuccessAlert>
+      ) : null}
+
+      {resendState.status === "error" ? (
+        <AuthFormErrorAlert className="mb-4 text-left">
+          {resendState.message}
+        </AuthFormErrorAlert>
+      ) : null}
+
+      <div className="space-y-5 text-left">
+        <div className="space-y-2">
+          <label htmlFor="confirm-email-input" className="text-sm font-medium">
+            Correo electrónico
+          </label>
+          <AuthIconInput
+            id="confirm-email-input"
+            name="email"
+            type="email"
+            icon={Mail}
+            placeholder="tu@email.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="email"
+            disabled={isLoading}
+          />
+        </div>
+
+        <Button
+          type="button"
+          variant="outline"
+          className="h-10 w-full cursor-pointer shadow-sm"
+          disabled={isLoading}
+          aria-busy={isLoading}
+          onClick={() => void handleResend()}
+        >
+          {isLoading ? (
+            <>
+              <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
+              Enviando…
+            </>
+          ) : (
+            "Reenviar correo de verificación"
+          )}
+        </Button>
+      </div>
+
+      <p className="mt-6 text-center text-sm text-muted-foreground">
+        <Link
+          href={ROUTES.login}
+          className="font-medium text-foreground hover:underline"
+        >
+          Volver al inicio de sesión
+        </Link>
+      </p>
+    </AuthFormShell>
+  )
+}

--- a/features/auth/components/forgot-password-form.tsx
+++ b/features/auth/components/forgot-password-form.tsx
@@ -2,10 +2,17 @@
 
 import Link from "next/link"
 import { useState } from "react"
-import { ArrowLeft, Loader2 } from "lucide-react"
+import { ArrowLeft, KeyRound, Loader2, Mail } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+import { AuthFormAlternateAction } from "@/features/auth/components/auth-form-footer"
+import {
+  AuthFormErrorAlert,
+  AuthFormSuccessAlert,
+} from "@/features/auth/components/auth-form-feedback"
+import { AuthFormHeader } from "@/features/auth/components/auth-form-header"
+import { AuthFormShell } from "@/features/auth/components/auth-form-shell"
+import { AuthIconInput } from "@/features/auth/components/auth-icon-input"
 import { requestPasswordReset } from "@/features/auth/services/auth"
 import { ApiError, parseApiErrorBody } from "@/lib/api-client"
 import { ROUTES } from "@/lib/constants"
@@ -74,39 +81,32 @@ export function ForgotPasswordForm() {
   const showForm = state.status === "idle" || state.status === "loading"
 
   return (
-    <div className="rounded-xl border bg-card p-8 shadow-sm">
-      <div className="mb-6 text-center">
-        <h2 className="text-xl font-semibold">Recuperar contraseña</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Te enviaremos un enlace para restablecer tu contraseña
-        </p>
-      </div>
+    <AuthFormShell>
+      <AuthFormHeader
+        eyebrow={{ icon: KeyRound, label: "Recuperación segura" }}
+        title="Recuperar contraseña"
+        description="Te enviaremos un enlace para restablecer tu contraseña"
+      />
 
       {state.status === "success" ? (
-        <p
-          className="rounded-md bg-green-50 p-3 text-sm text-green-800 dark:bg-green-950 dark:text-green-200"
-          role="status"
-        >
-          {state.message}
-        </p>
+        <AuthFormSuccessAlert>{state.message}</AuthFormSuccessAlert>
       ) : null}
 
       {state.status === "error" ? (
-        <p className="mb-4 text-sm text-destructive" role="alert">
-          {state.message}
-        </p>
+        <AuthFormErrorAlert className="mb-4">{state.message}</AuthFormErrorAlert>
       ) : null}
 
       {showForm ? (
-        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
           <div className="space-y-2">
             <label htmlFor="email" className="text-sm font-medium">
               Correo electrónico
             </label>
-            <Input
+            <AuthIconInput
               id="email"
               name="email"
               type="email"
+              icon={Mail}
               autoComplete="email"
               placeholder="tu@email.com"
               required
@@ -114,7 +114,11 @@ export function ForgotPasswordForm() {
             />
           </div>
 
-          <Button type="submit" className="w-full" disabled={isLoading}>
+          <Button
+            type="submit"
+            className="h-10 w-full cursor-pointer shadow-sm"
+            disabled={isLoading}
+          >
             {isLoading && <Loader2 className="mr-2 size-4 animate-spin" />}
             Enviar enlace de recuperación
           </Button>
@@ -126,25 +130,26 @@ export function ForgotPasswordForm() {
           <Button
             type="button"
             variant="secondary"
-            className="w-full"
+            className="h-10 w-full cursor-pointer shadow-sm"
             onClick={() => setState({ status: "idle" })}
           >
             Enviar otro correo
           </Button>
-          <Button variant="outline" className="w-full" asChild>
+          <Button variant="outline" className="h-10 w-full cursor-pointer" asChild>
             <Link href={ROUTES.login}>Ir al inicio de sesión</Link>
           </Button>
         </div>
       ) : null}
 
-      <div className="mt-6 text-center">
-        <Button variant="link" size="sm" asChild>
-          <Link href={ROUTES.login}>
-            <ArrowLeft className="mr-1.5 size-4" />
-            Volver al inicio de sesión
-          </Link>
-        </Button>
-      </div>
-    </div>
+      <AuthFormAlternateAction>
+        <Link
+          href={ROUTES.login}
+          className="inline-flex items-center font-medium text-foreground hover:underline"
+        >
+          <ArrowLeft className="mr-1.5 size-4" />
+          Volver al inicio de sesión
+        </Link>
+      </AuthFormAlternateAction>
+    </AuthFormShell>
   )
 }

--- a/features/auth/components/forgot-password-form.tsx
+++ b/features/auth/components/forgot-password-form.tsx
@@ -13,6 +13,7 @@ import {
 import { AuthFormHeader } from "@/features/auth/components/auth-form-header"
 import { AuthFormShell } from "@/features/auth/components/auth-form-shell"
 import { AuthIconInput } from "@/features/auth/components/auth-icon-input"
+import { rateLimitUserMessage } from "@/features/auth/lib/rate-limit-message"
 import { requestPasswordReset } from "@/features/auth/services/auth"
 import { ApiError, parseApiErrorBody } from "@/lib/api-client"
 import { ROUTES } from "@/lib/constants"
@@ -26,16 +27,6 @@ type ForgotUiState =
   | { status: "loading" }
   | { status: "success"; message: string }
   | { status: "error"; message: string }
-
-function rateLimitUserMessage(retryAfter?: string | null): string {
-  if (retryAfter) {
-    const seconds = Number.parseInt(retryAfter, 10)
-    if (!Number.isNaN(seconds) && seconds > 0) {
-      return `Demasiadas solicitudes. Vuelve a intentarlo en ${seconds} segundos.`
-    }
-  }
-  return "Demasiadas solicitudes. Espera un momento e inténtalo de nuevo."
-}
 
 export function ForgotPasswordForm() {
   const [state, setState] = useState<ForgotUiState>({ status: "idle" })

--- a/features/auth/components/login-form.tsx
+++ b/features/auth/components/login-form.tsx
@@ -25,9 +25,9 @@ export function LoginForm() {
   return (
     <AuthFormShell>
       <AuthFormHeader
-        eyebrow={{ icon: ShieldCheck, label: "Acceso seguro" }}
-        title="Iniciar sesión"
-        description="Bienvenido de nuevo, ingresa tus credenciales para continuar"
+        eyebrow={{ icon: ShieldCheck, label: "Tu espacio protegido" }}
+        title="Bienvenido de nuevo"
+        description="Introduce tu correo y contraseña para entrar a tu cuenta"
       />
 
       <form action={formAction} className="space-y-5">
@@ -54,7 +54,7 @@ export function LoginForm() {
               href={ROUTES.forgotPassword}
               className="text-xs text-muted-foreground hover:text-foreground"
             >
-              ¿Olvidaste tu contraseña?
+              ¿La has olvidado?
             </Link>
           </div>
           <AuthIconInput
@@ -82,19 +82,18 @@ export function LoginForm() {
       </form>
 
       <AuthFormTrustNote>
-        Queremos que accedas con confianza: cuidamos tu sesión con responsabilidad
-        para que tu experiencia con{" "}
-        <span className="font-bold text-foreground">Cloudflax</span> sea segura
-        y tranquila.
+        Cuidamos tu sesión para que en{" "}
+        <span className="font-bold text-foreground">Cloudflax</span> puedas
+        centrarte en tu negocio, no en preocuparte por la seguridad.
       </AuthFormTrustNote>
 
       <AuthFormAlternateAction>
-        ¿No tienes cuenta?{" "}
+        ¿Primera vez aquí?{" "}
         <Link
           href={ROUTES.register}
           className="font-medium text-foreground hover:underline"
         >
-          Regístrate
+          Crea tu cuenta
         </Link>
       </AuthFormAlternateAction>
     </AuthFormShell>

--- a/features/auth/components/login-form.tsx
+++ b/features/auth/components/login-form.tsx
@@ -2,11 +2,19 @@
 
 import { useActionState } from "react"
 import Link from "next/link"
+import { Loader2, Lock, Mail, ShieldCheck } from "lucide-react"
+
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+import {
+  AuthFormAlternateAction,
+  AuthFormTrustNote,
+} from "@/features/auth/components/auth-form-footer"
+import { AuthFormErrorAlert } from "@/features/auth/components/auth-form-feedback"
+import { AuthFormHeader } from "@/features/auth/components/auth-form-header"
+import { AuthFormShell } from "@/features/auth/components/auth-form-shell"
+import { AuthIconInput } from "@/features/auth/components/auth-icon-input"
 import { login } from "@/features/auth/actions/auth"
 import { ROUTES } from "@/lib/constants"
-import { Loader2, Lock, Mail, ShieldCheck } from "lucide-react"
 
 export function LoginForm() {
   const [errorMessage, formAction, isPending] = useActionState(
@@ -15,34 +23,26 @@ export function LoginForm() {
   )
 
   return (
-    <div className="mx-2 mt-4 rounded-2xl bg-background/60 px-8 py-12 sm:mx-0 sm:px-10 sm:py-14">
-      <div className="mb-7 space-y-3 text-center">
-        <div className="mx-auto inline-flex items-center text-xs font-medium text-muted-foreground">
-          <ShieldCheck className="mr-1.5 size-3.5 text-primary" />
-          Acceso seguro
-        </div>
-        <h2 className="text-2xl font-semibold tracking-tight">Iniciar sesión</h2>
-        <p className="text-sm text-muted-foreground">
-          Bienvenido de nuevo, ingresa tus credenciales para continuar
-        </p>
-      </div>
+    <AuthFormShell>
+      <AuthFormHeader
+        eyebrow={{ icon: ShieldCheck, label: "Acceso seguro" }}
+        title="Iniciar sesión"
+        description="Bienvenido de nuevo, ingresa tus credenciales para continuar"
+      />
 
       <form action={formAction} className="space-y-5">
         <div className="space-y-2">
           <label htmlFor="email" className="text-sm font-medium">
             Correo electrónico
           </label>
-          <div className="relative">
-            <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              id="email"
-              name="email"
-              type="email"
-              placeholder="tu@email.com"
-              className="h-10 pl-9"
-              required
-            />
-          </div>
+          <AuthIconInput
+            id="email"
+            name="email"
+            type="email"
+            icon={Mail}
+            placeholder="tu@email.com"
+            required
+          />
         </div>
 
         <div className="space-y-2">
@@ -57,24 +57,19 @@ export function LoginForm() {
               ¿Olvidaste tu contraseña?
             </Link>
           </div>
-          <div className="relative">
-            <Lock className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              id="password"
-              name="password"
-              type="password"
-              placeholder="••••••••"
-              className="h-10 pl-9"
-              required
-            />
-          </div>
+          <AuthIconInput
+            id="password"
+            name="password"
+            type="password"
+            icon={Lock}
+            placeholder="••••••••"
+            required
+          />
         </div>
 
-        {errorMessage && (
-          <p className="rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-            {errorMessage}
-          </p>
-        )}
+        {errorMessage ? (
+          <AuthFormErrorAlert>{errorMessage}</AuthFormErrorAlert>
+        ) : null}
 
         <Button
           type="submit"
@@ -86,14 +81,14 @@ export function LoginForm() {
         </Button>
       </form>
 
-      <p className="mx-auto mt-6 max-w-sm text-center text-xs leading-relaxed text-muted-foreground">
+      <AuthFormTrustNote>
         Queremos que accedas con confianza: cuidamos tu sesión con responsabilidad
         para que tu experiencia con{" "}
         <span className="font-bold text-foreground">Cloudflax</span> sea segura
         y tranquila.
-      </p>
+      </AuthFormTrustNote>
 
-      <p className="mt-6 text-center text-sm text-muted-foreground">
+      <AuthFormAlternateAction>
         ¿No tienes cuenta?{" "}
         <Link
           href={ROUTES.register}
@@ -101,7 +96,7 @@ export function LoginForm() {
         >
           Regístrate
         </Link>
-      </p>
-    </div>
+      </AuthFormAlternateAction>
+    </AuthFormShell>
   )
 }

--- a/features/auth/components/login-form.tsx
+++ b/features/auth/components/login-form.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { login } from "@/features/auth/actions/auth"
 import { ROUTES } from "@/lib/constants"
-import { Loader2 } from "lucide-react"
+import { Loader2, Lock, Mail, ShieldCheck } from "lucide-react"
 
 export function LoginForm() {
   const [errorMessage, formAction, isPending] = useActionState(
@@ -15,26 +15,34 @@ export function LoginForm() {
   )
 
   return (
-    <div className="rounded-xl border bg-card p-8 shadow-sm">
-      <div className="mb-6 text-center">
-        <h2 className="text-xl font-semibold">Iniciar sesión</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Ingresa tus credenciales para acceder
+    <div className="mx-2 mt-4 rounded-2xl bg-background/60 px-8 py-12 sm:mx-0 sm:px-10 sm:py-14">
+      <div className="mb-7 space-y-3 text-center">
+        <div className="mx-auto inline-flex items-center text-xs font-medium text-muted-foreground">
+          <ShieldCheck className="mr-1.5 size-3.5 text-primary" />
+          Acceso seguro
+        </div>
+        <h2 className="text-2xl font-semibold tracking-tight">Iniciar sesión</h2>
+        <p className="text-sm text-muted-foreground">
+          Bienvenido de nuevo, ingresa tus credenciales para continuar
         </p>
       </div>
 
-      <form action={formAction} className="space-y-4">
+      <form action={formAction} className="space-y-5">
         <div className="space-y-2">
           <label htmlFor="email" className="text-sm font-medium">
             Correo electrónico
           </label>
-          <Input
-            id="email"
-            name="email"
-            type="email"
-            placeholder="tu@email.com"
-            required
-          />
+          <div className="relative">
+            <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              id="email"
+              name="email"
+              type="email"
+              placeholder="tu@email.com"
+              className="h-10 pl-9"
+              required
+            />
+          </div>
         </div>
 
         <div className="space-y-2">
@@ -49,24 +57,41 @@ export function LoginForm() {
               ¿Olvidaste tu contraseña?
             </Link>
           </div>
-          <Input
-            id="password"
-            name="password"
-            type="password"
-            placeholder="••••••••"
-            required
-          />
+          <div className="relative">
+            <Lock className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              id="password"
+              name="password"
+              type="password"
+              placeholder="••••••••"
+              className="h-10 pl-9"
+              required
+            />
+          </div>
         </div>
 
         {errorMessage && (
-          <p className="text-sm text-destructive">{errorMessage}</p>
+          <p className="rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {errorMessage}
+          </p>
         )}
 
-        <Button type="submit" className="w-full" disabled={isPending}>
+        <Button
+          type="submit"
+          className="h-10 w-full cursor-pointer shadow-sm"
+          disabled={isPending}
+        >
           {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
           Iniciar sesión
         </Button>
       </form>
+
+      <p className="mx-auto mt-6 max-w-sm text-center text-xs leading-relaxed text-muted-foreground">
+        Queremos que accedas con confianza: cuidamos tu sesión con responsabilidad
+        para que tu experiencia con{" "}
+        <span className="font-bold text-foreground">Cloudflax</span> sea segura
+        y tranquila.
+      </p>
 
       <p className="mt-6 text-center text-sm text-muted-foreground">
         ¿No tienes cuenta?{" "}

--- a/features/auth/components/register-form.tsx
+++ b/features/auth/components/register-form.tsx
@@ -100,6 +100,15 @@ function RegisterSuccessNotice({
                 "Reenviar correo de verificación"
               )}
             </Button>
+            <span className="hidden sm:inline" aria-hidden>
+              ·
+            </span>
+            <Link
+              href={`${ROUTES.confirmEmail}?email=${encodeURIComponent(registeredEmail)}`}
+              className={successLinkClass}
+            >
+              Instrucciones y reenvío
+            </Link>
           </>
         ) : null}
         <span className="hidden sm:inline" aria-hidden>

--- a/features/auth/components/register-form.tsx
+++ b/features/auth/components/register-form.tsx
@@ -15,24 +15,13 @@ import { AuthFormHeader } from "@/features/auth/components/auth-form-header"
 import { AuthFormShell } from "@/features/auth/components/auth-form-shell"
 import { AuthIconInput } from "@/features/auth/components/auth-icon-input"
 import { register } from "@/features/auth/actions/auth"
+import {
+  RESEND_VERIFICATION_NEUTRAL_SUCCESS,
+  resendVerificationErrorFromApiError,
+} from "@/features/auth/lib/resend-verification"
 import { resendVerificationEmail } from "@/features/auth/services/auth"
-import { ApiError, parseApiErrorBody } from "@/lib/api-client"
+import { ApiError } from "@/lib/api-client"
 import { ROUTES } from "@/lib/constants"
-
-const RESEND_SUCCESS_FALLBACK =
-  "If the email exists, a verification link has been sent"
-
-function resendVerificationUserMessage(code: string, fallback: string): string {
-  switch (code) {
-    case "EMAIL_ALREADY_VERIFIED":
-      return "Este correo ya está verificado. Puedes iniciar sesión."
-    case "RATE_LIMITED":
-    case "RATE_LIMIT_EXCEEDED":
-      return "Demasiadas solicitudes de verificación. Inténtalo más tarde."
-    default:
-      return fallback
-  }
-}
 
 type ResendUiState =
   | { status: "idle" }
@@ -65,17 +54,13 @@ function RegisterSuccessNotice({
       const text = res.message?.trim()
       setResendState({
         status: "success",
-        message: text || RESEND_SUCCESS_FALLBACK,
+        message: text || RESEND_VERIFICATION_NEUTRAL_SUCCESS,
       })
     } catch (error) {
       if (error instanceof ApiError) {
-        const parsed = parseApiErrorBody(error.body)
-        const code = parsed?.error.code ?? ""
-        const fallback =
-          parsed?.error.message ?? `No se pudo reenviar el correo (${error.status}).`
         setResendState({
           status: "error",
-          message: resendVerificationUserMessage(code, fallback),
+          message: resendVerificationErrorFromApiError(error),
         })
         return
       }

--- a/features/auth/components/register-form.tsx
+++ b/features/auth/components/register-form.tsx
@@ -1,10 +1,19 @@
 "use client"
 
 import Link from "next/link"
-import { Loader2 } from "lucide-react"
+import { Loader2, Lock, Mail, UserPlus, UserRound } from "lucide-react"
 import { useActionState, useState } from "react"
+
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+import { AuthFormAlternateAction } from "@/features/auth/components/auth-form-footer"
+import {
+  AuthFormErrorAlert,
+  AuthFormFieldError,
+  AuthFormSuccessAlert,
+} from "@/features/auth/components/auth-form-feedback"
+import { AuthFormHeader } from "@/features/auth/components/auth-form-header"
+import { AuthFormShell } from "@/features/auth/components/auth-form-shell"
+import { AuthIconInput } from "@/features/auth/components/auth-icon-input"
 import { register } from "@/features/auth/actions/auth"
 import { resendVerificationEmail } from "@/features/auth/services/auth"
 import { ApiError, parseApiErrorBody } from "@/lib/api-client"
@@ -36,6 +45,9 @@ interface RegisterSuccessNoticeProps {
   registeredEmail?: string
   isPendingForm: boolean
 }
+
+const successLinkClass =
+  "font-medium text-emerald-900 underline underline-offset-4 hover:underline dark:text-emerald-50"
 
 function RegisterSuccessNotice({
   message,
@@ -75,7 +87,7 @@ function RegisterSuccessNotice({
   }
 
   return (
-    <div className="mb-4 rounded-md bg-green-50 p-3 text-sm text-green-800 dark:bg-green-950 dark:text-green-200">
+    <AuthFormSuccessAlert className="mb-4">
       <p className="flex flex-wrap items-center gap-x-1 gap-y-2">
         <span>{message}</span>
         {registeredEmail ? (
@@ -86,7 +98,7 @@ function RegisterSuccessNotice({
             <Button
               type="button"
               variant="link"
-              className="h-auto min-h-0 p-0 text-sm font-medium text-green-800 underline-offset-4 hover:text-green-900 hover:underline dark:text-green-200 dark:hover:text-green-100"
+              className={`h-auto min-h-0 p-0 text-sm ${successLinkClass}`}
               disabled={resendState.status === "loading" || isPendingForm}
               aria-busy={resendState.status === "loading"}
               onClick={() => void handleResendVerification()}
@@ -108,21 +120,24 @@ function RegisterSuccessNotice({
         <span className="hidden sm:inline" aria-hidden>
           ·
         </span>
-        <Link href={ROUTES.login} className="font-medium underline underline-offset-4">
+        <Link href={ROUTES.login} className={successLinkClass}>
           Ir al login
         </Link>
       </p>
       {resendState.status === "success" ? (
-        <p className="mt-2 text-xs text-green-900/90 dark:text-green-100/90" role="status">
+        <p
+          className="mt-2 text-xs text-emerald-900/90 dark:text-emerald-50/90"
+          role="status"
+        >
           {resendState.message}
         </p>
       ) : null}
       {resendState.status === "error" ? (
-        <p className="mt-2 text-xs font-medium text-red-900 dark:text-red-200" role="alert">
+        <p className="mt-2 text-xs font-medium text-destructive" role="alert">
           {resendState.message}
         </p>
       ) : null}
-    </div>
+    </AuthFormSuccessAlert>
   )
 }
 
@@ -130,13 +145,12 @@ export function RegisterForm() {
   const [state, formAction, isPending] = useActionState(register, undefined)
 
   return (
-    <div className="rounded-xl border bg-card p-8 shadow-sm">
-      <div className="mb-6 text-center">
-        <h2 className="text-xl font-semibold">Crear cuenta</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Completa el formulario para registrarte
-        </p>
-      </div>
+    <AuthFormShell>
+      <AuthFormHeader
+        eyebrow={{ icon: UserPlus, label: "Nueva cuenta" }}
+        title="Crear cuenta"
+        description="Completa el formulario para registrarte"
+      />
 
       {state?.success && (
         <RegisterSuccessNotice
@@ -147,78 +161,84 @@ export function RegisterForm() {
         />
       )}
 
-      {state && !state.success && state.message && (
-        <p className="mb-4 text-sm text-destructive">{state.message}</p>
-      )}
+      {state && !state.success && state.message ? (
+        <AuthFormErrorAlert className="mb-4">{state.message}</AuthFormErrorAlert>
+      ) : null}
 
-      <form action={formAction} className="space-y-4">
+      <form action={formAction} className="space-y-5">
         <div className="space-y-2">
           <label htmlFor="name" className="text-sm font-medium">
             Nombre
           </label>
-          <Input
+          <AuthIconInput
             id="name"
             name="name"
+            icon={UserRound}
             placeholder="Juan Pérez"
             required
             aria-invalid={!!state?.errors?.name}
             aria-describedby={state?.errors?.name ? "name-error" : undefined}
           />
-          {state?.errors?.name && (
-            <p id="name-error" className="text-xs text-destructive" role="alert">
+          {state?.errors?.name ? (
+            <AuthFormFieldError id="name-error">
               {state.errors.name[0]}
-            </p>
-          )}
+            </AuthFormFieldError>
+          ) : null}
         </div>
 
         <div className="space-y-2">
           <label htmlFor="email" className="text-sm font-medium">
             Correo electrónico
           </label>
-          <Input
+          <AuthIconInput
             id="email"
             name="email"
             type="email"
+            icon={Mail}
             placeholder="tu@email.com"
             required
             aria-invalid={!!state?.errors?.email}
             aria-describedby={state?.errors?.email ? "email-error" : undefined}
           />
-          {state?.errors?.email && (
-            <p id="email-error" className="text-xs text-destructive" role="alert">
+          {state?.errors?.email ? (
+            <AuthFormFieldError id="email-error">
               {state.errors.email[0]}
-            </p>
-          )}
+            </AuthFormFieldError>
+          ) : null}
         </div>
 
         <div className="space-y-2">
           <label htmlFor="password" className="text-sm font-medium">
             Contraseña
           </label>
-          <Input
+          <AuthIconInput
             id="password"
             name="password"
             type="password"
+            icon={Lock}
             placeholder="••••••••"
             required
             aria-invalid={!!state?.errors?.password}
-            aria-describedby={state?.errors?.password ? "password-error" : undefined}
+            aria-describedby={
+              state?.errors?.password ? "password-error" : undefined
+            }
           />
-          {state?.errors?.password && (
-            <p id="password-error" className="text-xs text-destructive" role="alert">
+          {state?.errors?.password ? (
+            <AuthFormFieldError id="password-error">
               {state.errors.password[0]}
-            </p>
-          )}
+            </AuthFormFieldError>
+          ) : null}
         </div>
 
         <div className="space-y-2">
           <label htmlFor="confirmPassword" className="text-sm font-medium">
             Confirmar contraseña
           </label>
-          <Input
+          <AuthIconInput
             id="confirmPassword"
             name="confirmPassword"
             type="password"
+            icon={Lock}
             placeholder="••••••••"
             required
             aria-invalid={!!state?.errors?.confirmPassword}
@@ -226,24 +246,24 @@ export function RegisterForm() {
               state?.errors?.confirmPassword ? "confirmPassword-error" : undefined
             }
           />
-          {state?.errors?.confirmPassword && (
-            <p
-              id="confirmPassword-error"
-              className="text-xs text-destructive"
-              role="alert"
-            >
+          {state?.errors?.confirmPassword ? (
+            <AuthFormFieldError id="confirmPassword-error">
               {state.errors.confirmPassword[0]}
-            </p>
-          )}
+            </AuthFormFieldError>
+          ) : null}
         </div>
 
-        <Button type="submit" className="w-full" disabled={isPending}>
+        <Button
+          type="submit"
+          className="h-10 w-full cursor-pointer shadow-sm"
+          disabled={isPending}
+        >
           {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
           Crear cuenta
         </Button>
       </form>
 
-      <p className="mt-6 text-center text-sm text-muted-foreground">
+      <AuthFormAlternateAction>
         ¿Ya tienes cuenta?{" "}
         <Link
           href={ROUTES.login}
@@ -251,7 +271,7 @@ export function RegisterForm() {
         >
           Inicia sesión
         </Link>
-      </p>
-    </div>
+      </AuthFormAlternateAction>
+    </AuthFormShell>
   )
 }

--- a/features/auth/components/reset-password-form.tsx
+++ b/features/auth/components/reset-password-form.tsx
@@ -2,10 +2,15 @@
 
 import Link from "next/link"
 import { useState } from "react"
-import { CheckCircle2, Loader2, XCircle } from "lucide-react"
+import { CheckCircle2, KeyRound, Loader2, Lock, XCircle } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+import { AuthFormAlternateAction } from "@/features/auth/components/auth-form-footer"
+import { AuthFormErrorAlert } from "@/features/auth/components/auth-form-feedback"
+import { AuthFormHeader } from "@/features/auth/components/auth-form-header"
+import { AuthFormShell } from "@/features/auth/components/auth-form-shell"
+import { AuthFormStatusPanel } from "@/features/auth/components/auth-form-status"
+import { AuthIconInput } from "@/features/auth/components/auth-icon-input"
 import { resetPassword } from "@/features/auth/services/auth"
 import { ApiError, parseApiErrorBody } from "@/lib/api-client"
 import { ROUTES } from "@/lib/constants"
@@ -87,78 +92,74 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
 
   if (missingToken) {
     return (
-      <div className="rounded-xl border bg-card p-8 shadow-sm text-center">
-        <div className="mx-auto mb-4 flex size-16 items-center justify-center rounded-full bg-destructive/10">
-          <XCircle className="size-8 text-destructive" aria-hidden />
-        </div>
-        <h2 className="text-xl font-semibold">Enlace no válido</h2>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Falta el token de recuperación o el enlace está incompleto. Solicita un
-          nuevo correo desde recuperar contraseña.
-        </p>
-        <div className="mt-8 space-y-3">
-          <Button className="w-full" asChild>
+      <AuthFormShell className="text-center">
+        <AuthFormStatusPanel
+          icon={<XCircle className="size-8 text-destructive" aria-hidden />}
+          title="Enlace no válido"
+          description="Falta el token de recuperación o el enlace está incompleto. Solicita un nuevo correo desde recuperar contraseña."
+          iconRingClassName="bg-destructive/10"
+        />
+        <div className="space-y-3">
+          <Button
+            className="h-10 w-full cursor-pointer shadow-sm"
+            asChild
+          >
             <Link href={ROUTES.forgotPassword}>Solicitar nuevo enlace</Link>
           </Button>
-          <Button variant="outline" className="w-full" asChild>
+          <Button variant="outline" className="h-10 w-full cursor-pointer" asChild>
             <Link href={ROUTES.login}>Ir al inicio de sesión</Link>
           </Button>
         </div>
-      </div>
+      </AuthFormShell>
     )
   }
 
   if (state.status === "success") {
     return (
-      <div className="rounded-xl border bg-card p-8 shadow-sm text-center">
-        <div className="mx-auto mb-4 flex size-16 items-center justify-center rounded-full bg-primary/10">
-          <CheckCircle2 className="size-8 text-green-500" aria-hidden />
-        </div>
-        <h2 className="text-xl font-semibold">Contraseña actualizada</h2>
-        <p className="mt-2 text-sm text-muted-foreground" role="status">
-          {state.message}
-        </p>
-        <div className="mt-8">
-          <Button className="w-full" asChild>
+      <AuthFormShell className="text-center">
+        <AuthFormStatusPanel
+          icon={<CheckCircle2 className="size-8 text-emerald-500" aria-hidden />}
+          title="Contraseña actualizada"
+          description={state.message}
+          descriptionRole="status"
+        />
+        <div>
+          <Button className="h-10 w-full cursor-pointer shadow-sm" asChild>
             <Link href={ROUTES.login}>Ir al inicio de sesión</Link>
           </Button>
         </div>
-      </div>
+      </AuthFormShell>
     )
   }
 
   const isLoading = state.status === "loading"
 
   return (
-    <div className="rounded-xl border bg-card p-8 shadow-sm">
-      <div className="mb-6 text-center">
-        <h2 className="text-xl font-semibold">Nueva contraseña</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Elige una contraseña segura para tu cuenta
-        </p>
-      </div>
+    <AuthFormShell>
+      <AuthFormHeader
+        eyebrow={{ icon: KeyRound, label: "Nueva clave" }}
+        title="Nueva contraseña"
+        description="Elige una contraseña segura para tu cuenta"
+      />
 
       {state.status === "error" ? (
-        <p className="mb-4 text-sm text-destructive" role="alert">
-          {state.message}
-        </p>
+        <AuthFormErrorAlert className="mb-4">{state.message}</AuthFormErrorAlert>
       ) : null}
 
       {fieldError ? (
-        <p className="mb-4 text-sm text-destructive" role="alert">
-          {fieldError}
-        </p>
+        <AuthFormErrorAlert className="mb-4">{fieldError}</AuthFormErrorAlert>
       ) : null}
 
-      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
         <div className="space-y-2">
           <label htmlFor="password" className="text-sm font-medium">
             Nueva contraseña
           </label>
-          <Input
+          <AuthIconInput
             id="password"
             name="password"
             type="password"
+            icon={Lock}
             autoComplete="new-password"
             placeholder="••••••••"
             required
@@ -176,10 +177,11 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
           <label htmlFor="confirmPassword" className="text-sm font-medium">
             Confirmar contraseña
           </label>
-          <Input
+          <AuthIconInput
             id="confirmPassword"
             name="confirmPassword"
             type="password"
+            icon={Lock}
             autoComplete="new-password"
             placeholder="••••••••"
             required
@@ -189,20 +191,24 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
           />
         </div>
 
-        <Button type="submit" className="w-full" disabled={isLoading}>
+        <Button
+          type="submit"
+          className="h-10 w-full cursor-pointer shadow-sm"
+          disabled={isLoading}
+        >
           {isLoading && <Loader2 className="mr-2 size-4 animate-spin" />}
           Guardar contraseña
         </Button>
       </form>
 
-      <p className="mt-6 text-center text-sm text-muted-foreground">
+      <AuthFormAlternateAction>
         <Link
           href={ROUTES.login}
           className="font-medium text-foreground hover:underline"
         >
           Volver al inicio de sesión
         </Link>
-      </p>
-    </div>
+      </AuthFormAlternateAction>
+    </AuthFormShell>
   )
 }

--- a/features/auth/components/reset-password-form.tsx
+++ b/features/auth/components/reset-password-form.tsx
@@ -11,6 +11,7 @@ import { AuthFormHeader } from "@/features/auth/components/auth-form-header"
 import { AuthFormShell } from "@/features/auth/components/auth-form-shell"
 import { AuthFormStatusPanel } from "@/features/auth/components/auth-form-status"
 import { AuthIconInput } from "@/features/auth/components/auth-icon-input"
+import { rateLimitUserMessage } from "@/features/auth/lib/rate-limit-message"
 import { resetPassword } from "@/features/auth/services/auth"
 import { ApiError, parseApiErrorBody } from "@/lib/api-client"
 import { ROUTES } from "@/lib/constants"
@@ -74,12 +75,19 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
       })
     } catch (error) {
       if (error instanceof ApiError) {
+        if (error.status === 429) {
+          setState({
+            status: "error",
+            message: rateLimitUserMessage(error.retryAfter),
+          })
+          return
+        }
         const parsed = parseApiErrorBody(error.body)
         const message =
           parsed?.error.message ??
           (error.status === 422
             ? "El enlace no es válido o ha expirado. Solicita uno nuevo desde recuperar contraseña."
-            : "No pudimos restablecer la contraseña. Inténtalo de nuevo.")
+            : `No pudimos restablecer la contraseña (${error.status}). Inténtalo de nuevo.`)
         setState({ status: "error", message })
         return
       }

--- a/features/auth/components/reset-password-form.tsx
+++ b/features/auth/components/reset-password-form.tsx
@@ -12,12 +12,14 @@ import { AuthFormShell } from "@/features/auth/components/auth-form-shell"
 import { AuthFormStatusPanel } from "@/features/auth/components/auth-form-status"
 import { AuthIconInput } from "@/features/auth/components/auth-icon-input"
 import { rateLimitUserMessage } from "@/features/auth/lib/rate-limit-message"
+import {
+  RESET_PASSWORD_MAX_LENGTH,
+  RESET_PASSWORD_MIN_LENGTH,
+  validateResetPasswordPair,
+} from "@/features/auth/lib/reset-password-validation"
 import { resetPassword } from "@/features/auth/services/auth"
 import { ApiError, parseApiErrorBody } from "@/lib/api-client"
 import { ROUTES } from "@/lib/constants"
-
-const PASSWORD_MIN = 8
-const PASSWORD_MAX = 72
 
 type ResetUiState =
   | { status: "idle" }
@@ -27,19 +29,6 @@ type ResetUiState =
 
 interface ResetPasswordFormProps {
   token: string | undefined
-}
-
-function validatePasswords(
-  password: string,
-  confirm: string,
-): string | null {
-  if (password.length < PASSWORD_MIN || password.length > PASSWORD_MAX) {
-    return `La contraseña debe tener entre ${PASSWORD_MIN} y ${PASSWORD_MAX} caracteres.`
-  }
-  if (password !== confirm) {
-    return "Las contraseñas no coinciden."
-  }
-  return null
 }
 
 export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
@@ -57,7 +46,7 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
     const password = (fd.get("password") as string) ?? ""
     const confirmPassword = (fd.get("confirmPassword") as string) ?? ""
 
-    const validation = validatePasswords(password, confirmPassword)
+    const validation = validateResetPasswordPair(password, confirmPassword)
     if (validation) {
       setFieldError(validation)
       return
@@ -171,13 +160,14 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
             autoComplete="new-password"
             placeholder="••••••••"
             required
-            minLength={PASSWORD_MIN}
-            maxLength={PASSWORD_MAX}
+            minLength={RESET_PASSWORD_MIN_LENGTH}
+            maxLength={RESET_PASSWORD_MAX_LENGTH}
             disabled={isLoading}
             aria-invalid={Boolean(fieldError)}
           />
           <p className="text-xs text-muted-foreground">
-            Entre {PASSWORD_MIN} y {PASSWORD_MAX} caracteres
+            Entre {RESET_PASSWORD_MIN_LENGTH} y {RESET_PASSWORD_MAX_LENGTH}{" "}
+            caracteres
           </p>
         </div>
 
@@ -193,8 +183,8 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
             autoComplete="new-password"
             placeholder="••••••••"
             required
-            minLength={PASSWORD_MIN}
-            maxLength={PASSWORD_MAX}
+            minLength={RESET_PASSWORD_MIN_LENGTH}
+            maxLength={RESET_PASSWORD_MAX_LENGTH}
             disabled={isLoading}
           />
         </div>

--- a/features/auth/lib/decode-access-token-payload.test.ts
+++ b/features/auth/lib/decode-access-token-payload.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { decodeAccessTokenIdentity } from "./decode-access-token-payload.ts"
+
+test("decodeAccessTokenIdentity reads user_id and email from JWT payload", () => {
+  const payload = Buffer.from(
+    JSON.stringify({ user_id: "usr_1", email: "hi@example.com" }),
+  ).toString("base64url")
+  const token = `hdr.${payload}.sig`
+  assert.deepEqual(decodeAccessTokenIdentity(token), {
+    userId: "usr_1",
+    email: "hi@example.com",
+  })
+})
+
+test("decodeAccessTokenIdentity returns null for malformed token", () => {
+  assert.equal(decodeAccessTokenIdentity("not-a-jwt"), null)
+  assert.equal(decodeAccessTokenIdentity("only.two"), null)
+})
+
+test("decodeAccessTokenIdentity returns null when claims are missing", () => {
+  const payload = Buffer.from(JSON.stringify({ sub: "x" })).toString(
+    "base64url",
+  )
+  assert.equal(decodeAccessTokenIdentity(`h.${payload}.s`), null)
+})

--- a/features/auth/lib/decode-access-token-payload.ts
+++ b/features/auth/lib/decode-access-token-payload.ts
@@ -1,0 +1,27 @@
+export interface AccessTokenIdentity {
+  userId: string
+  email: string
+}
+
+/** Lee el payload del JWT sin verificar firma (el backend ya emitió el token). */
+export function decodeAccessTokenIdentity(
+  accessToken: string,
+): AccessTokenIdentity | null {
+  try {
+    const parts = accessToken.split(".")
+    if (parts.length < 2 || !parts[1]) return null
+    const json = Buffer.from(parts[1], "base64url").toString("utf-8")
+    const data = JSON.parse(json) as unknown
+    if (!data || typeof data !== "object") return null
+    const o = data as Record<string, unknown>
+    const userId = o.user_id
+    const email = o.email
+    if (typeof userId !== "string" || typeof email !== "string") return null
+    const uid = userId.trim()
+    const em = email.trim()
+    if (!uid || !em) return null
+    return { userId: uid, email: em }
+  } catch {
+    return null
+  }
+}

--- a/features/auth/lib/login-credentials-error.ts
+++ b/features/auth/lib/login-credentials-error.ts
@@ -1,0 +1,37 @@
+import { CredentialsSignin } from "next-auth"
+
+import { ApiError, parseApiErrorBody } from "@/lib/api-client"
+
+const UNVERIFIED_EMAIL_CODES = new Set([
+  "EMAIL_NOT_VERIFIED",
+  "EMAIL_VERIFICATION_REQUIRED",
+])
+
+function throwCredentialsSignin(
+  code: string,
+  cause?: Record<string, unknown>,
+): never {
+  const err = new CredentialsSignin()
+  err.code = code
+  if (cause) err.cause = { ...err.cause, ...cause }
+  throw err
+}
+
+export function throwInvalidAccessTokenPayload(): never {
+  throwCredentialsSignin("invalid_session")
+}
+
+/** Mapea fallos de `POST /auth/login` a códigos seguros para Auth.js (query / server action). */
+export function throwFromLoginApiError(error: ApiError): never {
+  if (error.status === 429) {
+    throwCredentialsSignin("rate_limited", {
+      retryAfter: error.retryAfter ?? null,
+    })
+  }
+  const parsed = parseApiErrorBody(error.body)
+  const apiCode = parsed?.error.code ?? ""
+  if (UNVERIFIED_EMAIL_CODES.has(apiCode)) {
+    throwCredentialsSignin("email_not_verified")
+  }
+  throwCredentialsSignin("credentials")
+}

--- a/features/auth/lib/rate-limit-message.ts
+++ b/features/auth/lib/rate-limit-message.ts
@@ -1,0 +1,10 @@
+/** User-facing copy when the API returns 429; uses Retry-After when present. */
+export function rateLimitUserMessage(retryAfter?: string | null): string {
+  if (retryAfter) {
+    const seconds = Number.parseInt(retryAfter, 10)
+    if (!Number.isNaN(seconds) && seconds > 0) {
+      return `Demasiadas solicitudes. Vuelve a intentarlo en ${seconds} segundos.`
+    }
+  }
+  return "Demasiadas solicitudes. Espera un momento e inténtalo de nuevo."
+}

--- a/features/auth/lib/resend-verification.ts
+++ b/features/auth/lib/resend-verification.ts
@@ -1,0 +1,33 @@
+import { ApiError, parseApiErrorBody } from "@/lib/api-client"
+
+import { rateLimitUserMessage } from "@/features/auth/lib/rate-limit-message"
+
+/** Neutral copy when the API returns 200 sin mensaje (no revela si el email existe). */
+export const RESEND_VERIFICATION_NEUTRAL_SUCCESS =
+  "Si el correo está registrado, recibirás un enlace de verificación."
+
+export function resendVerificationErrorMessageForCode(
+  code: string,
+  fallback: string,
+): string {
+  switch (code) {
+    case "EMAIL_ALREADY_VERIFIED":
+      return "Este correo ya está verificado. Puedes iniciar sesión."
+    case "RATE_LIMITED":
+    case "RATE_LIMIT_EXCEEDED":
+      return "Demasiadas solicitudes de verificación. Inténtalo más tarde."
+    default:
+      return fallback
+  }
+}
+
+export function resendVerificationErrorFromApiError(error: ApiError): string {
+  if (error.status === 429) {
+    return rateLimitUserMessage(error.retryAfter)
+  }
+  const parsed = parseApiErrorBody(error.body)
+  const code = parsed?.error.code ?? ""
+  const fallback =
+    parsed?.error.message ?? `No se pudo reenviar el correo (${error.status}).`
+  return resendVerificationErrorMessageForCode(code, fallback)
+}

--- a/features/auth/lib/reset-password-validation.test.ts
+++ b/features/auth/lib/reset-password-validation.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  RESET_PASSWORD_MAX_LENGTH,
+  RESET_PASSWORD_MIN_LENGTH,
+  validateResetPasswordPair,
+} from "./reset-password-validation.ts"
+
+test("validateResetPasswordPair accepts password in 8–72 range with matching confirm", () => {
+  assert.equal(
+    validateResetPasswordPair("abcdefgh", "abcdefgh"),
+    null,
+  )
+  assert.equal(
+    validateResetPasswordPair("a".repeat(RESET_PASSWORD_MAX_LENGTH), "a".repeat(RESET_PASSWORD_MAX_LENGTH)),
+    null,
+  )
+})
+
+test("validateResetPasswordPair rejects password shorter than minimum", () => {
+  const msg = validateResetPasswordPair("abc", "abc")
+  assert.ok(msg)
+  assert.match(msg!, new RegExp(String(RESET_PASSWORD_MIN_LENGTH)))
+})
+
+test("validateResetPasswordPair rejects password longer than maximum", () => {
+  const p = "a".repeat(RESET_PASSWORD_MAX_LENGTH + 1)
+  const msg = validateResetPasswordPair(p, p)
+  assert.ok(msg)
+  assert.match(msg!, new RegExp(String(RESET_PASSWORD_MAX_LENGTH)))
+})
+
+test("validateResetPasswordPair rejects non-matching confirmation", () => {
+  const msg = validateResetPasswordPair("abcdefgh", "abcdefgH")
+  assert.equal(msg, "Las contraseñas no coinciden.")
+})

--- a/features/auth/lib/reset-password-validation.ts
+++ b/features/auth/lib/reset-password-validation.ts
@@ -1,0 +1,22 @@
+export const RESET_PASSWORD_MIN_LENGTH = 8
+export const RESET_PASSWORD_MAX_LENGTH = 72
+
+/**
+ * Client-side validation for reset password + confirmation (REQ-5).
+ * Returns a Spanish user-facing message or null if valid.
+ */
+export function validateResetPasswordPair(
+  password: string,
+  confirm: string,
+): string | null {
+  if (
+    password.length < RESET_PASSWORD_MIN_LENGTH ||
+    password.length > RESET_PASSWORD_MAX_LENGTH
+  ) {
+    return `La contraseña debe tener entre ${RESET_PASSWORD_MIN_LENGTH} y ${RESET_PASSWORD_MAX_LENGTH} caracteres.`
+  }
+  if (password !== confirm) {
+    return "Las contraseñas no coinciden."
+  }
+  return null
+}

--- a/features/auth/types.ts
+++ b/features/auth/types.ts
@@ -59,7 +59,7 @@ export interface ResendVerificationRequest {
   email: string
 }
 
-/** 200: `{ "message": "If the email exists, a verification link has been sent" }` */
+/** 200: cuerpo con `message` neutral (no revela si el email existe). */
 export interface ResendVerificationResponse {
   message: string
 }


### PR DESCRIPTION
## Summary
- Polish auth UI with shared form shell primitives and improved layout/copy consistency.
- Add confirm-email resend flow and improve register/login/reset flows with stronger API error handling.
- Harden token decoding and extract reset-password validation with dedicated unit tests.

Closes #16

## Test plan
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm run test
- [ ] Verify login/register/forgot/reset/confirm-email flows manually